### PR TITLE
feat: add favicon support for content repositories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,8 @@ my-content-repo/
 │   └── 2026-01-15-another-post.md
 ├── pages/
 │   └── about.md
+├── static/                   # User static files (favicon, images)
+│   └── favicon.ico           # Auto-detected and served at /favicon.ico
 ├── theme/                    # Optional custom theme
 │   └── ...
 └── config.yml
@@ -237,6 +239,7 @@ site:
   description: "A blog about things"
   author: "Your Name"
   url: "https://example.com"
+  favicon: "/static/user/custom-icon.png"  # Optional: override auto-detected favicon
 
 theme:
   name: default

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ site:
   description: "A blog about things"
   author: "Your Name"
   url: "https://yourdomain.com"
+  favicon: "/static/user/custom-icon.png"  # Optional
 
 theme:
   name: default
@@ -150,6 +151,21 @@ theme:
 posts:
   per_page: 10
 ```
+
+### Favicon
+
+Add a favicon by placing `favicon.ico`, `favicon.png`, or `favicon.svg` in your content repo's `static/` directory:
+
+```
+my-content-repo/
+├── posts/
+├── pages/
+├── static/
+│   └── favicon.ico    # Auto-detected
+└── config.yml
+```
+
+The favicon is automatically detected and served at `/favicon.ico`.
 
 ## Documentation
 

--- a/src/squishmark/models/content.py
+++ b/src/squishmark/models/content.py
@@ -61,6 +61,7 @@ class SiteConfig(BaseModel):
     description: str = ""
     author: str = ""
     url: str = ""
+    favicon: str | None = None  # Custom favicon URL, e.g., "/static/user/custom-icon.png"
 
 
 class ThemeConfig(BaseModel):

--- a/themes/default/base.html
+++ b/themes/default/base.html
@@ -8,6 +8,9 @@
     {% if site.author %}
     <meta name="author" content="{{ site.author }}">
     {% endif %}
+    {% if favicon_url %}
+    <link rel="icon" href="{{ favicon_url }}">
+    {% endif %}
     <link rel="stylesheet" href="/static/style.css">
     <link rel="stylesheet" href="/static/pygments.css">
     {% block head %}{% endblock %}


### PR DESCRIPTION
## Summary

- Add favicon support so users can place a favicon in their content repo's `static/` directory
- Auto-detect favicon files (`.ico`, `.png`, `.svg`) and serve with correct content type
- Add optional `site.favicon` config for custom favicon paths

## Changes

- **GitHubService**: Add binary file fetching (`get_binary_file()`) for images
- **main.py**: Add `/favicon.ico` fallback route and `/static/user/*` for user assets
- **ThemeEngine**: Add favicon detection with caching, pass `favicon_url` to templates
- **SiteConfig**: Add optional `favicon` field for custom paths
- **base.html**: Use detected `favicon_url` with correct extension
- **Docs**: Update CLAUDE.md and README.md with favicon setup instructions

## User Setup

```
content-repo/
├── static/
│   └── favicon.png  # or .ico or .svg
└── ...
```

## Test plan

- [x] Place `favicon.png` in `content/static/`
- [x] Verify HTML includes `<link rel="icon" href="/static/user/favicon.png">`
- [x] Verify `/static/user/favicon.png` returns PNG binary data
- [x] Verify `/favicon.ico` fallback route works

🤖 Generated with [Claude Code](https://claude.com/claude-code)