### PR TITLE
fix(ci): add --diff flag to ruff format for better error output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.14"
       - run: pip install ".[lint]"
       - run: ruff check .
-      - run: ruff format --check .
+      - run: ruff format --check --diff .
 
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `--diff` flag to `ruff format --check` in CI workflow
- Now shows actual formatting differences when checks fail, making it easier to identify what needs to be fixed

## Test plan
- [x] CI runs successfully on this PR
- [x] If there are formatting issues, the diff output will be visible in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)