### PR TITLE
fix: use correct 'build-target' property in fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@ primary_region = "sea"
 
 [build]
   dockerfile = "Dockerfile"
-  target = "prod"
+  build-target = "prod"
 
 [env]
   DATABASE_URL = "sqlite+aiosqlite:///data/squishmark.db"


### PR DESCRIPTION
## Summary
- Renames `target` to `build-target` in the `[build]` section of fly.toml
- Fixes schema validation error in tools like "Even Better TOML" VS Code extension

Fixes #18

## Test plan
- [x] Verify TOML validation passes in VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)