### PR TITLE
refactor(blue-tech): consistent accent styling for nav and hero titles

### DIFF
--- a/themes/blue-tech/base.html
+++ b/themes/blue-tech/base.html
@@ -21,7 +21,7 @@
 <body>
     <nav class="nav">
         <div class="nav-container">
-            <a href="/" class="nav-logo">{{ site.title }}</a>
+            <a href="/" class="nav-logo">{{ site.title | accent_first_word }}</a>
             <div class="nav-links">
                 <a href="/posts">Posts</a>
                 <a href="/about">About</a>

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -135,14 +135,23 @@ img {
 .nav-logo {
     font-family: var(--font-sans);
     font-size: 1.25rem;
-    font-weight: 700;
+    font-weight: 800;
     color: var(--color-text);
     white-space: nowrap;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    padding: 6px 10px;
+    margin: -6px -10px;
+    border: 2px solid transparent;
+    border-radius: var(--radius-sm);
+    transition: border-color var(--transition);
 }
 
 .nav-logo:hover {
+    border-color: var(--color-accent-light);
+}
+
+.nav-logo .accent {
     color: var(--color-accent);
 }
 


### PR DESCRIPTION
## Summary
- Apply `accent_first_word` filter to nav-logo to match hero-title styling
- Align font-weight (700 → 800) between nav-logo and hero-title
- Replace hover color change with rounded border outline for better UX

## Test plan
- [x] Verify nav-logo shows first word in accent color
- [x] Verify hero-title shows first word in same accent color
- [x] Verify hover state shows rounded border outline
- [x] Verify clicking nav-logo navigates to front page

🤖 Generated with [Claude Code](https://claude.com/claude-code)