### PR TITLE
fix(engine): allow extra fields in ThemeConfig for theme extensibility

### DIFF
--- a/src/squishmark/models/content.py
+++ b/src/squishmark/models/content.py
@@ -78,6 +78,9 @@ class ThemeConfig(BaseModel):
     nav_image: str | None = None
     hero_image: str | None = None
 
+    # Allow extra fields for extensibility
+    model_config = {"extra": "allow"}
+
 
 class PostsConfig(BaseModel):
     """Posts configuration from config.yml."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,9 @@
+"""Tests for Pydantic models."""
+
+from squishmark.models.content import ThemeConfig
+
+
+def test_themeconfig_allows_extra_fields():
+    """Extra fields in theme config should be accessible as attributes."""
+    config = ThemeConfig(name="test", custom_option="value")
+    assert config.custom_option == "value"


### PR DESCRIPTION
## Summary
- Add `model_config = {"extra": "allow"}` to `ThemeConfig`, matching the pattern already used by `FrontMatter`
- This allows theme authors to define custom fields in `config.yml` that are accessible as `{{ theme.fieldname }}` in templates
- Add test verifying extra fields are accepted and accessible

Closes #37

## Test plan
- [x] `test_themeconfig_allows_extra_fields` passes — extra fields on `ThemeConfig` are stored and accessible as attributes

*— Claude*