### PR TITLE
fix(posts): filter draft posts from public view

### DIFF
--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -71,9 +71,7 @@ async def list_posts(
 
     # Get all posts (admins can see drafts)
     include_drafts = _is_admin(request)
-    all_posts = await _get_all_posts(
-        github_service, markdown_service, include_drafts=include_drafts
-    )
+    all_posts = await _get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
 
     # Paginate
     per_page = config.posts.per_page
@@ -118,9 +116,7 @@ async def get_post(
 
     # Get all posts and find the matching one (admins can see drafts)
     include_drafts = _is_admin(request)
-    all_posts = await _get_all_posts(
-        github_service, markdown_service, include_drafts=include_drafts
-    )
+    all_posts = await _get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
 
     post = next((p for p in all_posts if p.slug == slug), None)
 


### PR DESCRIPTION
## Summary
- Add `_is_admin()` helper to optionally detect admin users without requiring authentication
- Pass `include_drafts=True` in both `list_posts` and `get_post` when the current user is an admin
- Anonymous/non-admin users continue to see draft posts filtered out (both from listings and direct URL access)
- Add 9 tests covering admin detection and draft filtering logic

Closes #25

## Test plan
- [x] All 60 tests pass (9 new + 51 existing)
- [x] Manual verification: anonymous users cannot see draft posts in `/posts` list
- [x] Manual verification: anonymous users get 404 when accessing draft post by direct URL
- [x] Manual verification: admin users can see draft posts in listings and by direct URL

*— Claude*