### PR TITLE
fix(theme): wire dynamic pygments CSS into theme templates

### DIFF
--- a/src/squishmark/services/theme/__init__.py
+++ b/src/squishmark/services/theme/__init__.py
@@ -1,5 +1,10 @@
 """Theme engine for Jinja2 template rendering."""
 
-from squishmark.services.theme.engine import ThemeEngine, get_theme_engine, reset_theme_engine
+from squishmark.services.theme.engine import (
+    THEME_PYGMENTS_DEFAULTS,
+    ThemeEngine,
+    get_theme_engine,
+    reset_theme_engine,
+)
 
-__all__ = ["ThemeEngine", "get_theme_engine", "reset_theme_engine"]
+__all__ = ["THEME_PYGMENTS_DEFAULTS", "ThemeEngine", "get_theme_engine", "reset_theme_engine"]

--- a/themes/blue-tech/base.html
+++ b/themes/blue-tech/base.html
@@ -15,7 +15,7 @@
     <link rel="icon" href="{{ favicon_url }}">
     {% endif %}
     <link rel="stylesheet" href="/static/{{ theme_name }}/style.css">
-    <link rel="stylesheet" href="/static/{{ theme_name }}/pygments.css">
+    <link rel="stylesheet" href="{{ pygments_css_url }}">
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/themes/default/base.html
+++ b/themes/default/base.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="{{ favicon_url }}">
     {% endif %}
     <link rel="stylesheet" href="/static/{{ theme_name }}/style.css">
-    <link rel="stylesheet" href="/static/{{ theme_name }}/pygments.css">
+    <link rel="stylesheet" href="{{ pygments_css_url }}">
     {% block head %}{% endblock %}
 </head>
 <body>

--- a/themes/terminal/base.html
+++ b/themes/terminal/base.html
@@ -15,7 +15,7 @@
     <link rel="icon" href="{{ favicon_url }}">
     {% endif %}
     <link rel="stylesheet" href="/static/{{ theme_name }}/css/style.css">
-    <link rel="stylesheet" href="/static/{{ theme_name }}/css/pygments.css">
+    <link rel="stylesheet" href="{{ pygments_css_url }}">
     {% block head %}{% endblock %}
 </head>
 <body class="bg-{{ theme.background|default('plain') }}">


### PR DESCRIPTION
## Summary

Completes the work started in #43 by connecting the dynamic `/pygments.css` route to theme templates. This ensures syntax highlighting works correctly when users override `pygments_style` in their `config.yml`.

- **Theme engine** (`engine.py`): Added `THEME_PYGMENTS_DEFAULTS` mapping and `resolve_pygments_css_url()` static method that chooses between static CSS (theme's hand-tuned file) and dynamic CSS (`/pygments.css`) based on whether the user's configured style matches the theme's built-in default
- **Templates**: All three themes (`default`, `blue-tech`, `terminal`) now use `{{ pygments_css_url }}` instead of hardcoded static paths
- **Tests**: Added 6 unit tests for `resolve_pygments_css_url` covering all themes, style override, and unknown theme fallback

### How it works

| Scenario | CSS URL served |
|----------|---------------|
| User style matches theme default (e.g., `monokai` on `terminal`) | `/static/terminal/css/pygments.css` (hand-tuned static file) |
| User overrides style (e.g., `dracula` on `terminal`) | `/pygments.css` (dynamically generated) |
| Unknown/custom theme | `/pygments.css` (dynamically generated) |

Closes #33

## Test plan

- [x] All 68 tests pass (`pytest`)
- [x] `ruff check` passes
- [x] Verify default theme with monokai renders static CSS
- [x] Verify overriding to dracula renders dynamic CSS
- [x] Verify terminal theme preserves custom monokai CSS

*— Claude*