### PR TITLE
feat(admin): notes edit/delete UI + fix broken create flow (#71)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "greenlet>=3.0.0",
     "authlib>=1.4.0",
     "itsdangerous>=2.2.0",
+    "python-multipart>=0.0.20",
 ]
 
 [project.optional-dependencies]

--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from squishmark.config import get_settings
 from squishmark.models.content import Config
-from squishmark.models.db import get_db_session
+from squishmark.models.db import Note, get_db_session
 from squishmark.services.analytics import AnalyticsService
 from squishmark.services.cache import get_cache
 from squishmark.services.github import get_github_service
@@ -20,6 +20,11 @@ from squishmark.services.theme import get_theme_engine, reset_theme_engine
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+def is_htmx(request: Request) -> bool:
+    """Return True when the request was made by HTMX."""
+    return request.headers.get("HX-Request") == "true"
 
 
 # Pydantic models for request/response
@@ -66,6 +71,9 @@ async def get_current_admin(request: Request) -> str:
 
     Raises HTTPException 401 if not authenticated.
     Raises HTTPException 403 if not an admin.
+
+    For HTMX requests, attaches an ``HX-Redirect`` header so the browser
+    is redirected to the login page without any client JavaScript.
     """
     settings = get_settings()
 
@@ -74,20 +82,79 @@ async def get_current_admin(request: Request) -> str:
         logger.warning("Auth bypassed - returning dev-admin user")
         return "dev-admin"
 
+    htmx_headers = {"HX-Redirect": "/auth/login"} if is_htmx(request) else None
+
     # Check for user in session (set by OAuth callback)
     user = request.session.get("user") if hasattr(request, "session") else None
 
     if user is None:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+        raise HTTPException(status_code=401, detail="Not authenticated", headers=htmx_headers)
 
     if user["login"] not in settings.admin_users_list:
-        raise HTTPException(status_code=403, detail="Not authorized")
+        raise HTTPException(status_code=403, detail="Not authorized", headers=htmx_headers)
 
     return user["login"]
 
 
 AdminUser = Annotated[str, Depends(get_current_admin)]
 DbSession = Annotated[AsyncSession, Depends(get_db_session)]
+
+
+def _to_note_response(note: Note) -> NoteResponse:
+    """Convert an ORM ``Note`` to the JSON-serializable ``NoteResponse``."""
+    return NoteResponse(
+        id=note.id,
+        path=note.path,
+        text=note.text,
+        is_public=note.is_public,
+        author=note.author,
+        created_at=note.created_at.isoformat(),
+        updated_at=note.updated_at.isoformat(),
+    )
+
+
+async def _render_note_partial(template_name: str, **context: Any) -> str:
+    """Render a notes admin partial using the active site theme."""
+    github_service = get_github_service()
+    config_data = await github_service.get_config()
+    theme_name = Config.from_dict(config_data).theme.name
+    theme_engine = await get_theme_engine(github_service)
+    return theme_engine.render_partial(template_name, theme_override=theme_name, **context)
+
+
+async def parse_note_create(request: Request) -> NoteCreate:
+    """Parse a ``NoteCreate`` payload from either form data or JSON.
+
+    HTMX submits standard HTML forms as ``application/x-www-form-urlencoded``.
+    Non-HTMX API callers continue to send JSON.
+    """
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data")):
+        form = await request.form()
+        return NoteCreate(
+            path=str(form.get("path", "")),
+            text=str(form.get("text", "")),
+            is_public="is_public" in form,
+        )
+    return NoteCreate.model_validate(await request.json())
+
+
+async def parse_note_update(request: Request) -> NoteUpdate:
+    """Parse a ``NoteUpdate`` payload from either form data or JSON.
+
+    For form submissions, ``is_public`` is always set explicitly (True if the
+    checkbox is present, False otherwise) — never None — so unchecking the
+    checkbox actually persists ``is_public=False`` rather than being treated
+    as "no change".
+    """
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data")):
+        form = await request.form()
+        return NoteUpdate(
+            text=str(form.get("text", "")),
+            is_public="is_public" in form,
+        )
+    return NoteUpdate.model_validate(await request.json())
 
 
 # Admin dashboard
@@ -122,18 +189,7 @@ async def admin_dashboard(
             config,
             user={"login": admin},
             analytics=analytics,
-            notes=[
-                NoteResponse(
-                    id=n.id,
-                    path=n.path,
-                    text=n.text,
-                    is_public=n.is_public,
-                    author=n.author,
-                    created_at=n.created_at.isoformat(),
-                    updated_at=n.updated_at.isoformat(),
-                )
-                for n in notes
-            ],
+            notes=[_to_note_response(n) for n in notes],
             cache_size=cache.size,
         )
     except Exception:
@@ -180,29 +236,20 @@ async def list_notes(
     session: DbSession,
 ) -> list[NoteResponse]:
     """List all notes."""
+    del admin  # auth side-effect only
     notes_service = NotesService(session)
     notes = await notes_service.get_all()
-    return [
-        NoteResponse(
-            id=n.id,
-            path=n.path,
-            text=n.text,
-            is_public=n.is_public,
-            author=n.author,
-            created_at=n.created_at.isoformat(),
-            updated_at=n.updated_at.isoformat(),
-        )
-        for n in notes
-    ]
+    return [_to_note_response(n) for n in notes]
 
 
-@router.post("/notes", status_code=201)
+@router.post("/notes", status_code=201, response_model=None)
 async def create_note(
+    request: Request,
     admin: AdminUser,
     session: DbSession,
-    note_data: NoteCreate,
-) -> NoteResponse:
-    """Create a new note."""
+) -> NoteResponse | HTMLResponse:
+    """Create a new note. Returns an HTML partial for HTMX, JSON otherwise."""
+    note_data = await parse_note_create(request)
     notes_service = NotesService(session)
     note = await notes_service.create(
         path=note_data.path,
@@ -210,25 +257,23 @@ async def create_note(
         author=admin,
         is_public=note_data.is_public,
     )
-    return NoteResponse(
-        id=note.id,
-        path=note.path,
-        text=note.text,
-        is_public=note.is_public,
-        author=note.author,
-        created_at=note.created_at.isoformat(),
-        updated_at=note.updated_at.isoformat(),
-    )
+    response = _to_note_response(note)
+    if is_htmx(request):
+        html = await _render_note_partial("admin/_note_item.html", note=response)
+        return HTMLResponse(content=html, status_code=201)
+    return response
 
 
-@router.put("/notes/{note_id}")
+@router.put("/notes/{note_id}", response_model=None)
 async def update_note(
+    request: Request,
     admin: AdminUser,
     session: DbSession,
     note_id: int,
-    note_data: NoteUpdate,
-) -> NoteResponse:
-    """Update a note."""
+) -> NoteResponse | HTMLResponse:
+    """Update a note. Returns an HTML partial for HTMX, JSON otherwise."""
+    del admin  # auth side-effect only
+    note_data = await parse_note_update(request)
     notes_service = NotesService(session)
     note = await notes_service.update_note(
         note_id=note_id,
@@ -237,30 +282,61 @@ async def update_note(
     )
     if note is None:
         raise HTTPException(status_code=404, detail="Note not found")
-
-    return NoteResponse(
-        id=note.id,
-        path=note.path,
-        text=note.text,
-        is_public=note.is_public,
-        author=note.author,
-        created_at=note.created_at.isoformat(),
-        updated_at=note.updated_at.isoformat(),
-    )
+    response = _to_note_response(note)
+    if is_htmx(request):
+        html = await _render_note_partial("admin/_note_item.html", note=response)
+        return HTMLResponse(content=html)
+    return response
 
 
-@router.delete("/notes/{note_id}")
+@router.delete("/notes/{note_id}", response_model=None)
 async def delete_note(
+    request: Request,
     admin: AdminUser,
     session: DbSession,
     note_id: int,
-) -> dict[str, str]:
-    """Delete a note."""
+) -> dict[str, str] | HTMLResponse:
+    """Delete a note. Returns an empty 200 for HTMX so the row is removed."""
+    del admin  # auth side-effect only
     notes_service = NotesService(session)
     deleted = await notes_service.delete(note_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Note not found")
+    if is_htmx(request):
+        return HTMLResponse(content="", status_code=200)
     return {"status": "deleted"}
+
+
+@router.get("/notes/{note_id}/edit", response_class=HTMLResponse)
+async def edit_note_form(
+    admin: AdminUser,
+    session: DbSession,
+    note_id: int,
+) -> HTMLResponse:
+    """Return the inline edit form for a note (HTMX swap target)."""
+    del admin  # auth side-effect only
+    notes_service = NotesService(session)
+    note = await notes_service.get_by_id(note_id)
+    if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    html = await _render_note_partial("admin/_note_edit_form.html", note=_to_note_response(note))
+    return HTMLResponse(content=html)
+
+
+@router.get("/notes/{note_id}/view", response_class=HTMLResponse)
+async def view_note(
+    admin: AdminUser,
+    session: DbSession,
+    note_id: int,
+) -> HTMLResponse:
+    """Return the read-only note row (used by the edit form's Cancel button)."""
+    del admin  # auth side-effect only
+    notes_service = NotesService(session)
+    note = await notes_service.get_by_id(note_id)
+    if note is None:
+        raise HTTPException(status_code=404, detail="Note not found")
+    html = await _render_note_partial("admin/_note_item.html", note=_to_note_response(note))
+    return HTMLResponse(content=html)
 
 
 # Cache management

--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -1,11 +1,12 @@
 """Admin routes for notes, analytics, and cache management."""
 
+import json
 import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from squishmark.config import get_settings
@@ -122,39 +123,69 @@ async def _render_note_partial(template_name: str, **context: Any) -> str:
     return theme_engine.render_partial(template_name, theme_override=theme_name, **context)
 
 
+def _is_form_request(request: Request) -> bool:
+    content_type = request.headers.get("content-type", "")
+    return content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data"))
+
+
+async def _load_json_body(request: Request) -> dict:
+    """Decode a JSON body, raising 422 on malformed JSON to match FastAPI defaults."""
+    try:
+        return await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid JSON: {exc.msg}") from exc
+
+
 async def parse_note_create(request: Request) -> NoteCreate:
     """Parse a ``NoteCreate`` payload from either form data or JSON.
 
     HTMX submits standard HTML forms as ``application/x-www-form-urlencoded``.
-    Non-HTMX API callers continue to send JSON.
+    Non-HTMX API callers continue to send JSON. Validation errors are returned
+    as 422 (matching FastAPI's default body-binding behavior) regardless of
+    which path produced them.
     """
-    content_type = request.headers.get("content-type", "")
-    if content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data")):
+    if _is_form_request(request):
         form = await request.form()
-        return NoteCreate(
-            path=str(form.get("path", "")),
-            text=str(form.get("text", "")),
-            is_public="is_public" in form,
-        )
-    return NoteCreate.model_validate(await request.json())
+        # Pass through what was actually sent: absent fields stay absent so
+        # Pydantic enforces required-ness instead of silently coercing to "".
+        data: dict[str, Any] = {"is_public": "is_public" in form}
+        if "path" in form:
+            data["path"] = str(form["path"])
+        if "text" in form:
+            data["text"] = str(form["text"])
+    else:
+        data = await _load_json_body(request)
+    try:
+        return NoteCreate.model_validate(data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
 
 
 async def parse_note_update(request: Request) -> NoteUpdate:
     """Parse a ``NoteUpdate`` payload from either form data or JSON.
 
-    For form submissions, ``is_public`` is always set explicitly (True if the
-    checkbox is present, False otherwise) — never None — so unchecking the
-    checkbox actually persists ``is_public=False`` rather than being treated
-    as "no change".
+    Form semantics:
+    - ``is_public`` is always set explicitly (True if the checkbox is present,
+      False otherwise) — never None — so unchecking the checkbox actually
+      persists ``is_public=False`` rather than being treated as "no change".
+    - ``text`` is left absent (``None``, meaning "no change") when the form
+      doesn't send it. The HTMX edit form always submits ``text`` because the
+      field is ``required``, so this only affects programmatic form callers
+      that intentionally omit the field.
+
+    Validation errors are returned as 422 from both paths.
     """
-    content_type = request.headers.get("content-type", "")
-    if content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data")):
+    if _is_form_request(request):
         form = await request.form()
-        return NoteUpdate(
-            text=str(form.get("text", "")),
-            is_public="is_public" in form,
-        )
-    return NoteUpdate.model_validate(await request.json())
+        data: dict[str, Any] = {"is_public": "is_public" in form}
+        if "text" in form:
+            data["text"] = str(form["text"])
+    else:
+        data = await _load_json_body(request)
+    try:
+        return NoteUpdate.model_validate(data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
 
 
 # Admin dashboard

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -293,11 +293,18 @@ class ThemeEngine:
         For HTMX swaps where we only need a self-contained snippet (no nav,
         no favicon, no GitHub fetches). The partial must not depend on
         site/theme/canonical context.
+
+        The previous ``current_theme`` is restored after rendering so concurrent
+        requests don't see each other's theme leak through this shared loader.
         """
-        if theme_override:
-            self.loader.current_theme = theme_override
-        template = self.env.get_template(template_name)
-        return template.render(**context)
+        previous_theme = self.loader.current_theme
+        try:
+            if theme_override:
+                self.loader.current_theme = theme_override
+            template = self.env.get_template(template_name)
+            return template.render(**context)
+        finally:
+            self.loader.current_theme = previous_theme
 
 
 # Global theme engine instance

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -282,6 +282,23 @@ class ThemeEngine:
         """Render the admin dashboard."""
         return await self.render("admin/admin.html", config, theme_override=theme_override, **context)
 
+    def render_partial(
+        self,
+        template_name: str,
+        theme_override: str | None = None,
+        **context: Any,
+    ) -> str:
+        """Render a small HTML fragment without the heavy default context.
+
+        For HTMX swaps where we only need a self-contained snippet (no nav,
+        no favicon, no GitHub fetches). The partial must not depend on
+        site/theme/canonical context.
+        """
+        if theme_override:
+            self.loader.current_theme = theme_override
+        template = self.env.get_template(template_name)
+        return template.render(**context)
+
 
 # Global theme engine instance
 _theme_engine: ThemeEngine | None = None

--- a/tests/test_admin_notes.py
+++ b/tests/test_admin_notes.py
@@ -1,5 +1,6 @@
 """Tests for the admin notes CRUD endpoints (JSON + HTMX dual responses)."""
 
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -315,6 +316,119 @@ async def test_get_current_admin_htmx_attaches_redirect_header():
 
     assert exc_info.value.status_code == 401
     assert exc_info.value.headers == {"HX-Redirect": "/auth/login"}
+
+
+@pytest.mark.asyncio
+async def test_create_note_invalid_json_returns_422():
+    """POST with malformed JSON body returns 422 (not 500)."""
+    from squishmark.routers.admin import create_note
+
+    request = MagicMock()
+    request.headers = {"content-type": "application/json"}
+    request.json = AsyncMock(side_effect=json.JSONDecodeError("Expecting value", "x", 0))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_note(request=request, admin="test-admin", session=AsyncMock())
+
+    assert exc_info.value.status_code == 422
+    assert "Invalid JSON" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_note_json_missing_required_returns_422():
+    """POST JSON missing required field returns 422 (not 500)."""
+    from squishmark.routers.admin import create_note
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_note(
+            request=_request(json_body={"path": "/x"}),  # missing 'text'
+            admin="test-admin",
+            session=AsyncMock(),
+        )
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_note_htmx_form_missing_path_returns_422():
+    """POST form missing 'path' returns 422 instead of silently coercing to ''."""
+    from squishmark.routers.admin import create_note
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_note(
+            request=_request(
+                hx=True,
+                content_type="application/x-www-form-urlencoded",
+                form_body={"text": "no path"},  # missing 'path'
+            ),
+            admin="test-admin",
+            session=AsyncMock(),
+        )
+
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_note_htmx_form_missing_text_leaves_text_unchanged():
+    """PUT form without 'text' field passes text=None so the stored value is preserved."""
+    from squishmark.routers.admin import update_note
+
+    mock_service = AsyncMock()
+    mock_service.update_note.return_value = _fake_note(text="unchanged", is_public=True)
+
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch("squishmark.routers.admin._render_note_partial", new=AsyncMock(return_value="<div></div>")),
+    ):
+        await update_note(
+            request=_request(
+                hx=True,
+                content_type="application/x-www-form-urlencoded",
+                form_body={"is_public": "true"},  # no 'text' field at all
+            ),
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=1,
+        )
+
+    mock_service.update_note.assert_called_once_with(note_id=1, text=None, is_public=True)
+
+
+@pytest.mark.asyncio
+async def test_render_partial_restores_current_theme():
+    """ThemeEngine.render_partial must restore the previous current_theme after rendering."""
+    from unittest.mock import MagicMock as MM
+
+    from squishmark.services.theme.engine import ThemeEngine
+
+    engine = ThemeEngine.__new__(ThemeEngine)
+    engine.loader = MM()
+    engine.loader.current_theme = "blue-tech"
+    engine.env = MM()
+    engine.env.get_template.return_value.render.return_value = "<div></div>"
+
+    engine.render_partial("admin/_note_item.html", theme_override="terminal")
+
+    assert engine.loader.current_theme == "blue-tech"
+
+
+@pytest.mark.asyncio
+async def test_render_partial_restores_theme_on_render_exception():
+    """The previous current_theme must be restored even if rendering raises."""
+    from unittest.mock import MagicMock as MM
+
+    from squishmark.services.theme.engine import ThemeEngine
+
+    engine = ThemeEngine.__new__(ThemeEngine)
+    engine.loader = MM()
+    engine.loader.current_theme = "default"
+    engine.env = MM()
+    engine.env.get_template.return_value.render.side_effect = RuntimeError("template crash")
+
+    with pytest.raises(RuntimeError, match="template crash"):
+        engine.render_partial("admin/_note_item.html", theme_override="terminal")
+
+    assert engine.loader.current_theme == "default"
 
 
 @pytest.mark.asyncio

--- a/tests/test_admin_notes.py
+++ b/tests/test_admin_notes.py
@@ -1,0 +1,335 @@
+"""Tests for the admin notes CRUD endpoints (JSON + HTMX dual responses)."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import HTMLResponse
+
+
+def _fake_note(
+    note_id: int = 1,
+    path: str = "/posts/hello",
+    text: str = "Original text",
+    is_public: bool = False,
+) -> MagicMock:
+    """Build a MagicMock that mimics the ORM ``Note`` shape."""
+    note = MagicMock()
+    note.id = note_id
+    note.path = path
+    note.text = text
+    note.is_public = is_public
+    note.author = "test-admin"
+    note.created_at = datetime(2026, 5, 16, 10, 0, 0)
+    note.updated_at = datetime(2026, 5, 16, 10, 0, 0)
+    return note
+
+
+def _request(
+    *,
+    hx: bool = False,
+    content_type: str = "application/json",
+    json_body: dict | None = None,
+    form_body: dict | None = None,
+) -> MagicMock:
+    """Build a mock Request with optional HTMX header and body."""
+    request = MagicMock()
+    headers = {"content-type": content_type}
+    if hx:
+        headers["HX-Request"] = "true"
+    request.headers = headers
+    request.json = AsyncMock(return_value=json_body or {})
+    request.form = AsyncMock(return_value=form_body or {})
+    return request
+
+
+@pytest.mark.asyncio
+async def test_create_note_json_returns_json_response():
+    """POST without HX-Request returns a NoteResponse JSON object."""
+    from squishmark.routers.admin import create_note
+
+    mock_service = AsyncMock()
+    mock_service.create.return_value = _fake_note(note_id=42, text="JSON note", is_public=True)
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        result = await create_note(
+            request=_request(json_body={"path": "/posts/x", "text": "JSON note", "is_public": True}),
+            admin="test-admin",
+            session=AsyncMock(),
+        )
+
+    assert not isinstance(result, HTMLResponse)
+    assert result.id == 42
+    assert result.text == "JSON note"
+    assert result.is_public is True
+    mock_service.create.assert_called_once_with(path="/posts/x", text="JSON note", author="test-admin", is_public=True)
+
+
+@pytest.mark.asyncio
+async def test_create_note_htmx_form_returns_html_partial():
+    """POST with HX-Request and form body returns an HTML partial."""
+    from squishmark.routers.admin import create_note
+
+    mock_service = AsyncMock()
+    mock_service.create.return_value = _fake_note(note_id=7, text="HTMX note")
+
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch(
+            "squishmark.routers.admin._render_note_partial",
+            new=AsyncMock(return_value='<div class="note-item" id="note-7"><p>HTMX note</p></div>'),
+        ) as mock_render,
+    ):
+        result = await create_note(
+            request=_request(
+                hx=True,
+                content_type="application/x-www-form-urlencoded",
+                form_body={"path": "/posts/y", "text": "HTMX note"},
+            ),
+            admin="test-admin",
+            session=AsyncMock(),
+        )
+
+    assert isinstance(result, HTMLResponse)
+    assert result.status_code == 201
+    assert b'id="note-7"' in result.body
+    mock_render.assert_awaited_once()
+    assert mock_render.call_args.args == ("admin/_note_item.html",)
+
+
+@pytest.mark.asyncio
+async def test_create_note_htmx_checkbox_omitted_persists_false():
+    """When the is_public checkbox is omitted from form data, is_public=False is persisted."""
+    from squishmark.routers.admin import create_note
+
+    mock_service = AsyncMock()
+    mock_service.create.return_value = _fake_note(is_public=False)
+
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch("squishmark.routers.admin._render_note_partial", new=AsyncMock(return_value="<div></div>")),
+    ):
+        await create_note(
+            request=_request(
+                hx=True,
+                content_type="application/x-www-form-urlencoded",
+                form_body={"path": "/posts/z", "text": "no checkbox"},
+            ),
+            admin="test-admin",
+            session=AsyncMock(),
+        )
+
+    mock_service.create.assert_called_once()
+    assert mock_service.create.call_args.kwargs["is_public"] is False
+
+
+@pytest.mark.asyncio
+async def test_update_note_htmx_toggle_off_persists_false():
+    """PUT form without is_public after note was public must persist is_public=False.
+
+    Guards the checkbox semantics: unchecked checkboxes are absent from form
+    data, but the user expects them to mean "off", not "no change".
+    """
+    from squishmark.routers.admin import update_note
+
+    mock_service = AsyncMock()
+    mock_service.update_note.return_value = _fake_note(is_public=False)
+
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch("squishmark.routers.admin._render_note_partial", new=AsyncMock(return_value="<div></div>")),
+    ):
+        await update_note(
+            request=_request(
+                hx=True,
+                content_type="application/x-www-form-urlencoded",
+                form_body={"text": "still here"},
+            ),
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=1,
+        )
+
+    mock_service.update_note.assert_called_once_with(note_id=1, text="still here", is_public=False)
+
+
+@pytest.mark.asyncio
+async def test_update_note_not_found_raises_404():
+    """PUT on a missing note returns 404."""
+    from squishmark.routers.admin import update_note
+
+    mock_service = AsyncMock()
+    mock_service.update_note.return_value = None
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        with pytest.raises(HTTPException) as exc_info:
+            await update_note(
+                request=_request(json_body={"text": "x"}),
+                admin="test-admin",
+                session=AsyncMock(),
+                note_id=999,
+            )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_note_htmx_returns_empty():
+    """DELETE with HX-Request returns an empty 200 so HTMX removes the row."""
+    from squishmark.routers.admin import delete_note
+
+    mock_service = AsyncMock()
+    mock_service.delete.return_value = True
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        result = await delete_note(
+            request=_request(hx=True),
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=1,
+        )
+
+    assert isinstance(result, HTMLResponse)
+    assert result.status_code == 200
+    assert result.body == b""
+
+
+@pytest.mark.asyncio
+async def test_delete_note_json_returns_status_dict():
+    """DELETE without HX-Request preserves the original JSON contract."""
+    from squishmark.routers.admin import delete_note
+
+    mock_service = AsyncMock()
+    mock_service.delete.return_value = True
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        result = await delete_note(
+            request=_request(),
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=1,
+        )
+
+    assert result == {"status": "deleted"}
+
+
+@pytest.mark.asyncio
+async def test_delete_note_not_found_raises_404():
+    """DELETE on a missing note returns 404."""
+    from squishmark.routers.admin import delete_note
+
+    mock_service = AsyncMock()
+    mock_service.delete.return_value = False
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_note(
+                request=_request(hx=True),
+                admin="test-admin",
+                session=AsyncMock(),
+                note_id=999,
+            )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_edit_note_form_renders_partial():
+    """GET /admin/notes/{id}/edit returns the edit-form partial."""
+    from squishmark.routers.admin import edit_note_form
+
+    mock_service = AsyncMock()
+    mock_service.get_by_id.return_value = _fake_note(note_id=3, text="edit me")
+
+    rendered = '<form class="note-edit-form"><textarea>edit me</textarea></form>'
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch("squishmark.routers.admin._render_note_partial", new=AsyncMock(return_value=rendered)) as mock_render,
+    ):
+        result = await edit_note_form(
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=3,
+        )
+
+    assert isinstance(result, HTMLResponse)
+    assert b"note-edit-form" in result.body
+    assert mock_render.call_args.args == ("admin/_note_edit_form.html",)
+
+
+@pytest.mark.asyncio
+async def test_view_note_renders_item_partial():
+    """GET /admin/notes/{id}/view returns the read-only item partial."""
+    from squishmark.routers.admin import view_note
+
+    mock_service = AsyncMock()
+    mock_service.get_by_id.return_value = _fake_note(note_id=3)
+
+    with (
+        patch("squishmark.routers.admin.NotesService", return_value=mock_service),
+        patch(
+            "squishmark.routers.admin._render_note_partial",
+            new=AsyncMock(return_value='<div class="note-item" id="note-3"></div>'),
+        ) as mock_render,
+    ):
+        result = await view_note(
+            admin="test-admin",
+            session=AsyncMock(),
+            note_id=3,
+        )
+
+    assert isinstance(result, HTMLResponse)
+    assert b'id="note-3"' in result.body
+    assert mock_render.call_args.args == ("admin/_note_item.html",)
+
+
+@pytest.mark.asyncio
+async def test_edit_form_not_found_raises_404():
+    """GET /admin/notes/{id}/edit on a missing note returns 404."""
+    from squishmark.routers.admin import edit_note_form
+
+    mock_service = AsyncMock()
+    mock_service.get_by_id.return_value = None
+
+    with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
+        with pytest.raises(HTTPException) as exc_info:
+            await edit_note_form(admin="test-admin", session=AsyncMock(), note_id=999)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_current_admin_htmx_attaches_redirect_header():
+    """HTMX requests with no session get an HX-Redirect header on 401."""
+    from squishmark.routers.admin import get_current_admin
+
+    request = MagicMock()
+    request.session = {}
+    request.headers = {"HX-Request": "true"}
+
+    with patch("squishmark.routers.admin.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(debug=False, dev_skip_auth=False, admin_users_list=[])
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_admin(request)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.headers == {"HX-Redirect": "/auth/login"}
+
+
+@pytest.mark.asyncio
+async def test_get_current_admin_non_htmx_omits_redirect_header():
+    """Non-HTMX requests get a plain 401 with no HX-Redirect header."""
+    from squishmark.routers.admin import get_current_admin
+
+    request = MagicMock()
+    request.session = {}
+    request.headers = {}
+
+    with patch("squishmark.routers.admin.get_settings") as mock_settings:
+        mock_settings.return_value = MagicMock(debug=False, dev_skip_auth=False, admin_users_list=[])
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_admin(request)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.headers is None

--- a/themes/blue-tech/admin/admin.html
+++ b/themes/blue-tech/admin/admin.html
@@ -98,25 +98,7 @@
 
             <div id="notes-list">
                 {% for note in notes %}
-                <div class="note-item" id="note-{{ note.id }}">
-                    <div class="note-header">
-                        <span class="note-path">{{ note.path }}</span>
-                        <span class="note-status {% if note.is_public %}public{% else %}private{% endif %}">
-                            {{ "Public" if note.is_public else "Private" }}
-                        </span>
-                    </div>
-                    <p class="note-text">{{ note.text }}</p>
-                    <div class="note-meta">
-                        <span>By {{ note.author }} on {{ note.created_at[:10] }}</span>
-                        <button class="btn btn-danger btn-sm"
-                                hx-delete="/admin/notes/{{ note.id }}"
-                                hx-target="#note-{{ note.id }}"
-                                hx-swap="outerHTML"
-                                hx-confirm="Delete this note?">
-                            Delete
-                        </button>
-                    </div>
-                </div>
+                {% include "admin/_note_item.html" %}
                 {% else %}
                 <p class="no-data">No notes yet</p>
                 {% endfor %}

--- a/themes/default/admin/_note_edit_form.html
+++ b/themes/default/admin/_note_edit_form.html
@@ -1,0 +1,26 @@
+<div class="note-item note-item-editing" id="note-{{ note.id }}">
+    <form class="note-edit-form"
+          hx-put="/admin/notes/{{ note.id }}"
+          hx-target="#note-{{ note.id }}"
+          hx-swap="outerHTML">
+        <div class="form-group">
+            <label for="note-{{ note.id }}-text">Note Text</label>
+            <textarea id="note-{{ note.id }}-text" name="text" rows="3" required>{{ note.text }}</textarea>
+        </div>
+        <div class="form-group">
+            <label>
+                <input type="checkbox" name="is_public" value="true" {% if note.is_public %}checked{% endif %}>
+                Make this note public
+            </label>
+        </div>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+            <button type="button" class="btn btn-secondary btn-sm"
+                    hx-get="/admin/notes/{{ note.id }}/view"
+                    hx-target="#note-{{ note.id }}"
+                    hx-swap="outerHTML">
+                Cancel
+            </button>
+        </div>
+    </form>
+</div>

--- a/themes/default/admin/_note_item.html
+++ b/themes/default/admin/_note_item.html
@@ -1,0 +1,27 @@
+<div class="note-item" id="note-{{ note.id }}">
+    <div class="note-header">
+        <span class="note-path">{{ note.path }}</span>
+        <span class="note-status {% if note.is_public %}public{% else %}private{% endif %}">
+            {{ "Public" if note.is_public else "Private" }}
+        </span>
+    </div>
+    <p class="note-text">{{ note.text }}</p>
+    <div class="note-meta">
+        <span>By {{ note.author }} on {{ note.created_at[:10] }}</span>
+        <div class="note-actions">
+            <button class="btn btn-secondary btn-sm"
+                    hx-get="/admin/notes/{{ note.id }}/edit"
+                    hx-target="#note-{{ note.id }}"
+                    hx-swap="outerHTML">
+                Edit
+            </button>
+            <button class="btn btn-danger btn-sm"
+                    hx-delete="/admin/notes/{{ note.id }}"
+                    hx-target="#note-{{ note.id }}"
+                    hx-swap="outerHTML"
+                    hx-confirm="Delete this note?">
+                Delete
+            </button>
+        </div>
+    </div>
+</div>

--- a/themes/default/admin/admin.html
+++ b/themes/default/admin/admin.html
@@ -95,25 +95,7 @@
 
             <div id="notes-list">
                 {% for note in notes %}
-                <div class="note-item" id="note-{{ note.id }}">
-                    <div class="note-header">
-                        <span class="note-path">{{ note.path }}</span>
-                        <span class="note-status {% if note.is_public %}public{% else %}private{% endif %}">
-                            {{ "Public" if note.is_public else "Private" }}
-                        </span>
-                    </div>
-                    <p class="note-text">{{ note.text }}</p>
-                    <div class="note-meta">
-                        <span>By {{ note.author }} on {{ note.created_at[:10] }}</span>
-                        <button class="btn btn-danger btn-sm"
-                                hx-delete="/admin/notes/{{ note.id }}"
-                                hx-target="#note-{{ note.id }}"
-                                hx-swap="outerHTML"
-                                hx-confirm="Delete this note?">
-                            Delete
-                        </button>
-                    </div>
-                </div>
+                {% include "admin/_note_item.html" %}
                 {% else %}
                 <p class="no-data">No notes yet</p>
                 {% endfor %}

--- a/themes/terminal/admin/admin.html
+++ b/themes/terminal/admin/admin.html
@@ -97,25 +97,7 @@
             </form>
             <div id="notes-list">
                 {% for note in notes %}
-                <div class="note-item" id="note-{{ note.id }}">
-                    <div class="note-header">
-                        <span class="note-path">{{ note.path }}</span>
-                        <span class="note-status {% if note.is_public %}public{% else %}private{% endif %}">
-                            {{ "Public" if note.is_public else "Private" }}
-                        </span>
-                    </div>
-                    <p class="note-text">{{ note.text }}</p>
-                    <div class="note-meta">
-                        <span>By {{ note.author }} on {{ note.created_at[:10] }}</span>
-                        <button class="btn btn-danger btn-sm"
-                                hx-delete="/admin/notes/{{ note.id }}"
-                                hx-target="#note-{{ note.id }}"
-                                hx-swap="outerHTML"
-                                hx-confirm="Delete this note?">
-                            Delete
-                        </button>
-                    </div>
-                </div>
+                {% include "admin/_note_item.html" %}
                 {% else %}
                 <p class="no-data">No notes yet</p>
                 {% endfor %}


### PR DESCRIPTION
## Summary

- Adds the missing edit/delete UI for notes in the admin dashboard.
- Fixes two pre-existing bugs in the same area: the create form was sending form-urlencoded to a JSON endpoint (422), and the delete button was swapping a JSON response into the DOM where the note used to be.
- Uses HTMX (already loaded in the admin templates) — endpoints now detect `HX-Request` and return rendered HTML partials. JSON behavior is preserved for non-HTMX callers (curl, future API).

## Approach

- New shared partials in `themes/default/admin/`: `_note_item.html` (read-only row with Edit + Delete) and `_note_edit_form.html` (inline edit form). The theme loader's default-theme fallback means `blue-tech` and `terminal` reuse them automatically — no per-theme duplication.
- New `ThemeEngine.render_partial(...)` returns a small HTML snippet without the heavy default render context (no nav/favicon/featured_posts).
- `admin.py` gains `is_htmx`, `parse_note_create`, `parse_note_update`, `_to_note_response`, `_render_note_partial` helpers. POST/PUT/DELETE branch on `HX-Request`. Two new GET routes power the inline edit/cancel flow.
- HTMX auth failures attach `HX-Redirect: /auth/login` so the browser bounces to login with no client JS.
- **Checkbox edge case**: unchecked `is_public` in an HTMX form PUT now persists `is_public=False` (the parser sets it explicitly), so toggling a note from public→private actually works.
- Added `python-multipart` to dependencies — required by Starlette's `request.form()`.

## Test plan

- [x] `python scripts/run-checks.py` — 4/4 checks pass (format, lint, 183 tests, pyright).
- [x] 13 new tests in `tests/test_admin_notes.py` cover the JSON path (preserved), the HTMX form path, the checkbox-off semantics, and HX-Redirect on auth failure.
- [x] Manual (default theme): create note → row appears at top; click Edit → inline form with current text + is_public state; modify text + uncheck public + Save → row reverts to read-only and shows "Private"; Cancel → unchanged; Delete + confirm → row disappears.
- [x] Manual (blue-tech): visually verified — Edit/Delete buttons styled correctly; edit/cancel flow works.
- [x] Manual (terminal): visually verified — Edit/Delete buttons styled correctly; edit form renders cleanly.
- [x] JSON contract: `curl -X PUT /admin/notes/3 -H 'Content-Type: application/json' -d '{"text":"x"}'` still returns `NoteResponse` JSON.

## Follow-ups (will file after this PR is open)

- **CSRF protection for admin mutations** — pre-existing gap. Admin POST/PUT/DELETE routes currently accept no CSRF token; this PR does not change that.
- **Empty-state restore after deleting the last note** — minor UX nit; the "No notes yet" placeholder won't reappear after HTMX-delete of the final row.

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)