### PR TITLE
chore(dx): tighten github skill — issue creation flow + Copilot review docs

### DIFF
--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -64,7 +64,7 @@ gh issue list --search "label:bug sort:updated-desc"
 
 ## Pull Requests
 
-See `references/pull-requests.md` for create, review, comment, and merge commands.
+See `references/pull-requests.md` for create, review, comment, merge, and Copilot review commands.
 
 ## Conventions
 

--- a/.claude/skills/github/SKILL.md
+++ b/.claude/skills/github/SKILL.md
@@ -34,32 +34,25 @@ Use the `gh` CLI for all GitHub operations. Run individual `gh` commands via the
 
 ### Creation Flow
 
-1. **Search for duplicates** before creating:
-   ```bash
-   gh issue list --search "keyword" --state all
-   ```
+A complete issue has **title + body + labels + milestone + type**. Don't ship partial issues.
 
-2. **Create the issue:**
+1. Search for duplicates: `gh issue list --search "keyword" --state all`
+2. Create with title, body, labels in one call:
    ```bash
-   gh issue create --title "Add dark mode" --body "$(cat <<'EOF'
-   ## Description
-   Add dark mode support.
-
-   ## Acceptance Criteria
-   - Toggle in settings
-   - Persists across sessions
+   gh issue create --title "..." --label "engine,enhancement" --body "$(cat <<'EOF'
+   ...
    EOF
-   )" --label "enhancement"
+   )"
    ```
-
-3. **Set issue type** — see `references/graphql.md` for GraphQL mutations, or use the helper script:
+3. Set milestone (default `SquishMark 1.0`; only ask if multiple are active):
+   `gh issue edit <num> --milestone "SquishMark 1.0"`
+4. Set type (`Feature`/`Bug`/`Task`):
    ```bash
-   python .claude/skills/github/scripts/github-issue-updater.py 42 --type task
+   python .claude/skills/github/scripts/github-issue-updater.py <num> --type feature
    ```
+   Or via GraphQL — see `references/graphql.md`.
 
-4. **Apply labels:** `gh issue edit 42 --add-label "engine,enhancement"` — see `references/labels.md`
-
-5. **Prompt about milestone** — ask the user. See `references/milestones.md`
+See `references/labels.md` and `references/milestones.md` for available values.
 
 ### Edit and Search
 

--- a/.claude/skills/github/references/pull-requests.md
+++ b/.claude/skills/github/references/pull-requests.md
@@ -36,6 +36,48 @@ EOF
 gh pr review 42 --approve --body "LGTM"
 ```
 
+## Copilot Code Review
+
+The Copilot reviewer is a GitHub App, **not** a workflow run or check — `gh run list` and `gh pr checks` won't show it. The signals live on the issue/PR timeline and reviews APIs.
+
+### Request
+
+```bash
+echo '{"reviewers": ["copilot-pull-request-reviewer[bot]"]}' \
+  | gh api repos/{owner}/{repo}/pulls/<num>/requested_reviewers -X POST --input -
+```
+
+The brackets in the login matter. `gh pr edit --add-reviewer copilot-pull-request-reviewer` returns 422; `reviewers: ["Copilot"]` is silently dropped.
+
+### Wait
+
+Two signals, in order:
+
+1. **`copilot_work_started`** — timeline event posted within seconds of the request, performed by app `copilot-pull-request-reviewer`. Confirms the bot picked up the request.
+   ```bash
+   gh api repos/{owner}/{repo}/issues/<num>/timeline --paginate \
+     --jq '.[] | select(.event=="copilot_work_started") | .created_at'
+   ```
+2. **Review submitted** — appears in `pulls/<num>/reviews` (typically <2 min later). After the review lands, allow ~60s before fetching inline comments — they lag the review.
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<num>/reviews \
+     --jq '.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")'
+   gh api repos/{owner}/{repo}/pulls/<num>/comments \
+     --jq '.[] | {id, path, line, body}'
+   ```
+
+### Reply to inline comments
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<num>/comments/<comment_id>/replies \
+  -X POST -f body="...
+*— Claude*"
+```
+
+### Re-review
+
+The bot reviews once per request. New commits don't auto-trigger a re-review — re-request the reviewer for a fresh pass.
+
 ## Merge
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ When planning implementation work, follow this workflow:
    - Prompt about GitHub issue tracking:
      - "Should we use an existing GitHub issue, create a new one, or skip issue tracking?"
      - If existing: ask for issue number
-     - If new: create issue with appropriate title/description
+     - If new: file via the `github` skill's full creation flow — **title + body + labels + milestone + type**. Don't ship a label-only issue.
    - Prompt about branch creation:
      - "Should we create a new branch for this work?"
      - Use **Conventional Commits style prefixes** matching the anticipated merge commit


### PR DESCRIPTION
## Summary

Two related tightenings of the `github` skill, no code changes.

**1. Issue creation flow** (`.claude/skills/github/SKILL.md`, `CLAUDE.md`)

After filing #79 with only labels (no milestone, no type), reshape the creation flow so the agent files complete issues by default:

- Replace 5 detachable steps with one checklist: **title + body + labels + milestone + type**.
- Default to the active milestone (`SquishMark 1.0`) instead of prompting, so it works in autonomous-mode runs.
- Add a one-line reinforcement in `CLAUDE.md` pointing at the skill's full flow.

**2. Copilot Code Review docs** (`.claude/skills/github/references/pull-requests.md`)

New section covering how to request a Copilot review and wait for it. Surfaced after I incorrectly reported "no workflow correlates to a Copilot review" — there isn't an Actions run or check-run, but there IS a `copilot_work_started` timeline event on the PR, performed by app `copilot-pull-request-reviewer`. The reference now documents:

- The working request payload (`copilot-pull-request-reviewer[bot]` with brackets — other variants 422 or get silently dropped).
- The two-signal wait: `copilot_work_started` timeline event (work started), then the reviews API (review submitted), then a ~60s lag for inline comments.
- Reply-to-inline-comment and re-request commands.
- The fact that new commits don't auto-trigger a re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)