### PR TITLE
docs(github): resolve Copilot threads before merging

### DIFF
--- a/.claude/skills/github/references/pull-requests.md
+++ b/.claude/skills/github/references/pull-requests.md
@@ -78,6 +78,18 @@ gh api repos/{owner}/{repo}/pulls/<num>/comments/<comment_id>/replies \
 
 The bot reviews once per request. New commits don't auto-trigger a re-review — re-request the reviewer for a fresh pass.
 
+### Resolve threads before merging
+
+`main` requires conversation resolution. Replying to a Copilot thread does **not** mark it resolved — that's a separate action. Without resolving, `gh pr merge` fails with `mergeStateStatus: BLOCKED` even with all checks green and no required approvals.
+
+```bash
+gh api graphql -f query='{repository(owner:"xeek-dev",name:"squishmark"){pullRequest(number:<num>){reviewThreads(first:50){nodes{id isResolved}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false) | .id' \
+| while read -r ID; do
+    gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' -f id="$ID"
+  done
+```
+
 ## Merge
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a "Resolve threads before merging" subsection to the Copilot Code Review docs.

Hit this on #78: all checks green, no required approvals, but `gh pr merge` returned `mergeStateStatus: BLOCKED` because the 3 Copilot threads weren't marked resolved. Replying to a thread doesn't resolve it — it's a separate `resolveReviewThread` GraphQL action. The new section ships the one-liner that resolves every unresolved thread on a PR.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)