### PR TITLE
chore(deps): add dependabot version updates for pip, github-actions, and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+updates:
+  # Python dependencies declared in pyproject.toml ([project] dependencies +
+  # optional-dependencies). There is no lock file, so Dependabot reads the
+  # version constraints directly.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in .github/workflows (ci.yml, conventional-commits.yml,
+  # release-please.yml).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Base image in the Dockerfile (FROM python:3.14-slim).
+  #
+  # KNOWN BLIND SPOT: the Dockerfile also pins `uv==0.9.26` via
+  # `RUN pip install --no-cache-dir uv==0.9.26`. Neither the docker ecosystem
+  # (which only tracks FROM lines) nor the pip ecosystem (which only reads
+  # pyproject.toml) sees that pin, so it must be bumped manually.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ python scripts/start-dev.py -b  # run in background (prints PID)
 docker compose up --build
 ```
 
+### Dependency Updates
+
+Dependency updates are automated weekly via [Dependabot](.github/dependabot.yml) across pip, GitHub Actions, and Docker, with minor and patch bumps grouped into a single PR per ecosystem.
+
 ## Tech Stack
 
 - **Python 3.14+** with FastAPI


### PR DESCRIPTION
Closes #87

## What

Adds `.github/dependabot.yml` with weekly version updates across all three of our ecosystems:

- **pip** — reads `pyproject.toml` (`[project]` dependencies + optional-dependencies; no lock file)
- **github-actions** — covers `ci.yml`, `conventional-commits.yml`, `release-please.yml`
- **docker** — watches `FROM python:3.14-slim`

All entries: weekly schedule, `open-pull-requests-limit: 10`, auto-label `dependencies` (label created), and `commit-message: prefix chore + scope` so Dependabot PRs arrive as `chore(deps): bump …` — passing the conventional-commits check and feeding release-please's changelog (#86) cleanly. Minor + patch bumps are grouped into one PR per ecosystem; majors arrive individually.

Also adds a Dependency Updates note to the README's Development section.

## Known blind spot (documented in-file)

The Dockerfile pins `uv==0.9.26` via `RUN pip install` — invisible to both the docker ecosystem (tracks only `FROM`) and pip (reads only `pyproject.toml`). That pin needs manual bumps.

## Verified

- YAML parses; `python scripts/run-checks.py` 4/4 (format, lint, 241 tests, pyright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)