### PR TITLE
test(routes): add integration tests for core http endpoints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,321 @@
+"""Shared fixtures for HTTP integration tests.
+
+These exercise the real ``create_app()`` (lifespan, SessionMiddleware, the
+custom HTML 404 handler) via ``TestClient`` used as a context manager. The
+GitHub content layer is replaced with an in-memory :class:`FakeGitHubService`
+so no network access is required.
+
+The autouse :func:`_reset_environment` fixture is the linchpin: it points every
+process-global singleton at per-test state and tears it all down afterwards so
+the pre-existing (non-integration) test modules stay green.
+"""
+
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import squishmark.services.github as github_module
+from squishmark.config import get_settings
+from squishmark.main import create_app
+from squishmark.services.cache import reset_cache
+from squishmark.services.github import GitHubBinaryFile, GitHubFile
+from squishmark.services.markdown import reset_markdown_service
+from squishmark.services.theme import reset_theme_engine
+
+
+class FakeGitHubService:
+    """Dict-backed stand-in for :class:`~squishmark.services.github.GitHubService`.
+
+    Matches the real public coroutine signatures so it can be dropped in as the
+    module-global ``_github_service``. ``list_directory`` derives a directory's
+    children from the keys of ``files`` (and ``binary_files``) by prefix match,
+    mirroring how the real service lists a GitHub/local directory.
+    """
+
+    def __init__(
+        self,
+        files: dict[str, str] | None = None,
+        binary_files: dict[str, bytes] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> None:
+        self.files: dict[str, str] = dict(files or {})
+        self.binary_files: dict[str, bytes] = dict(binary_files or {})
+        self.config: dict[str, Any] | None = config
+
+    async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
+        content = self.files.get(path)
+        if content is None:
+            return None
+        return GitHubFile(path=path, content=content)
+
+    async def get_binary_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubBinaryFile | None:
+        content = self.binary_files.get(path)
+        if content is None:
+            return None
+        return GitHubBinaryFile(path=path, content=content, content_type=_content_type_for(path))
+
+    async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
+        prefix = f"{path.rstrip('/')}/"
+        children: set[str] = set()
+        for key in (*self.files, *self.binary_files):
+            if key.startswith(prefix):
+                remainder = key[len(prefix) :]
+                # Only direct children (no nested subdirectories), matching the
+                # real service which lists a single directory level.
+                if "/" not in remainder:
+                    children.add(key)
+        return sorted(children)
+
+    async def get_config(self, use_cache: bool = True) -> dict[str, Any] | None:
+        return self.config
+
+    async def close(self) -> None:
+        return None
+
+
+_CONTENT_TYPES = {
+    ".ico": "image/x-icon",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".gif": "image/gif",
+    ".css": "text/css",
+    ".js": "application/javascript",
+}
+
+
+def _content_type_for(path: str) -> str:
+    for ext, ctype in _CONTENT_TYPES.items():
+        if path.lower().endswith(ext):
+            return ctype
+    return "application/octet-stream"
+
+
+# --- Default content -------------------------------------------------------
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "site": {
+        "title": "Test Blog",
+        "url": "https://test.example.com",
+        "description": "A blog for integration tests",
+        "author": "Test Author",
+    },
+    "theme": {"name": "default"},
+    "posts": {"per_page": 2},
+}
+
+
+def _post_body(title: str, *, draft: bool = False) -> str:
+    draft_line = "draft: true\n" if draft else ""
+    return f"---\ntitle: {title}\n{draft_line}---\n\n# {title}\n\nBody text for {title}.\n"
+
+
+def _page_body(title: str, *, visibility: str = "public") -> str:
+    return f"---\ntitle: {title}\nvisibility: {visibility}\n---\n\n# {title}\n\nPage body.\n"
+
+
+def default_files() -> dict[str, str]:
+    """Default published/draft posts (enough to paginate) plus pages.
+
+    Filenames carry ``YYYY-MM-DD-`` prefixes so slugs strip the date and dates
+    sort newest-first. ``per_page=2`` plus five published posts yields three
+    pages for anonymous users.
+    """
+    return {
+        "posts/2026-01-05-post-five.md": _post_body("Post Five"),
+        "posts/2026-01-04-post-four.md": _post_body("Post Four"),
+        "posts/2026-01-03-post-three.md": _post_body("Post Three"),
+        "posts/2026-01-02-post-two.md": _post_body("Post Two"),
+        "posts/2026-01-01-post-one.md": _post_body("Post One"),
+        "posts/2026-01-06-secret-draft.md": _post_body("Secret Draft", draft=True),
+        "pages/about.md": _page_body("About"),
+        "pages/secret.md": _page_body("Secret", visibility="hidden"),
+    }
+
+
+def default_binary_files() -> dict[str, bytes]:
+    """A favicon so :class:`FaviconDetector` and ``/favicon.ico`` resolve."""
+    # 1x1 transparent PNG.
+    png = bytes.fromhex(
+        "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+        "0000000a49444154789c6360000002000154a24f230000000049454e44ae426082"
+    )
+    return {"static/favicon.png": png}
+
+
+# --- Content factory -------------------------------------------------------
+
+
+@pytest.fixture
+def make_content() -> Callable[..., FakeGitHubService]:
+    """Factory producing a :class:`FakeGitHubService` with overridable content.
+
+    Defaults to the standard fixture content; pass ``files``/``binary_files``/
+    ``config`` to replace any slice for a given test.
+    """
+
+    def _factory(
+        files: dict[str, str] | None = None,
+        binary_files: dict[str, bytes] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> FakeGitHubService:
+        return FakeGitHubService(
+            files=default_files() if files is None else files,
+            binary_files=default_binary_files() if binary_files is None else binary_files,
+            config=DEFAULT_CONFIG if config is None else config,
+        )
+
+    return _factory
+
+
+# --- Autouse environment reset --------------------------------------------
+
+
+_INTEGRATION_MODULES = (
+    "test_routes_posts",
+    "test_routes_pages",
+    "test_routes_admin",
+    "test_routes_webhooks",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_environment(
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+    make_content: Callable[..., FakeGitHubService],
+) -> Iterator[FakeGitHubService | None]:
+    """Per-test isolation of every process-global singleton.
+
+    For the HTTP integration modules this also pins the environment the real
+    ``create_app()`` reads (file-based SQLite — ``:memory:`` loses tables across
+    the separate connections SQLAlchemy's async pool opens — plus secret/admin/
+    webhook config) and installs a default fake GitHub service as the module
+    global. Tests can swap in their own via ``github_module._github_service = ...``
+    before constructing a client.
+
+    The env-pinning is scoped to this PR's integration modules so it never
+    pollutes ``os.environ`` for the pre-existing suites — several of which build
+    a bare ``Settings()`` and assert on environment-derived defaults. The
+    singleton resets below run for *every* test and are side-effect free.
+    """
+    is_integration = request.module.__name__.rsplit(".", 1)[-1] in _INTEGRATION_MODULES
+
+    if is_integration:
+        db_path = tmp_path / "test.db"
+        monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+        monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+        monkeypatch.setenv("ADMIN_USERS", "admin-user")
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "test-webhook-secret")
+        monkeypatch.setenv("GITHUB_CONTENT_REPO", "testowner/testcontent")
+        monkeypatch.setenv("DEBUG", "false")
+        monkeypatch.setenv("DEV_SKIP_AUTH", "false")
+
+    get_settings.cache_clear()
+    reset_cache()
+    reset_markdown_service()
+    reset_theme_engine()
+
+    fake: FakeGitHubService | None = None
+    if is_integration:
+        fake = make_content()
+        github_module._github_service = fake
+
+    yield fake
+
+    github_module._github_service = None
+    get_settings.cache_clear()
+    reset_cache()
+    reset_markdown_service()
+    reset_theme_engine()
+
+
+# --- Clients ---------------------------------------------------------------
+
+_SEED_ROUTE = "/_test/seed-session"
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    """Anonymous client over the real ``create_app()`` with lifespan active."""
+    app = create_app()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def admin_client() -> Iterator[TestClient]:
+    """Client whose session is seeded with an admin user.
+
+    A test-only ``/_test/seed-session`` route writes ``request.session["user"]``;
+    TestClient's cookie jar then carries the signed session cookie on every
+    subsequent request. Pattern proven in ``test_csrf_integration.py``.
+
+    Uses an ``https`` base URL: with ``DEBUG=false`` the real app sets
+    ``SessionMiddleware(https_only=True)``, so the session cookie is only sent
+    back over a secure scheme.
+    """
+    app = create_app()
+
+    from fastapi import Request
+
+    @app.get(_SEED_ROUTE)
+    async def _seed(request: Request) -> dict:
+        request.session["user"] = {"login": "admin-user"}
+        return {"ok": True}
+
+    with TestClient(app, base_url="https://testserver") as test_client:
+        resp = test_client.get(_SEED_ROUTE)
+        assert resp.status_code == 200, resp.text
+        yield test_client
+
+
+@pytest.fixture
+def seeded_client() -> Iterator[Callable[[dict[str, Any]], TestClient]]:
+    """Factory yielding an https TestClient whose session is seeded with
+    arbitrary data (e.g. a non-admin ``user``).
+
+    Each call builds a fresh app/client; all created clients are closed at
+    teardown. Used for the "wrong user → 403" admin case.
+    """
+    clients: list[TestClient] = []
+
+    def _make(session_data: dict[str, Any]) -> TestClient:
+        app = create_app()
+
+        from fastapi import Request
+
+        @app.get(_SEED_ROUTE)
+        async def _seed(request: Request) -> dict:
+            for key, value in session_data.items():
+                request.session[key] = value
+            return {"ok": True}
+
+        test_client = TestClient(app, base_url="https://testserver")
+        test_client.__enter__()
+        resp = test_client.get(_SEED_ROUTE)
+        assert resp.status_code == 200, resp.text
+        clients.append(test_client)
+        return test_client
+
+    yield _make
+
+    for test_client in clients:
+        test_client.__exit__(None, None, None)
+
+
+@pytest.fixture
+def csrf_token() -> Callable[[TestClient], str]:
+    """Return a helper that fetches the CSRF token for an admin client."""
+
+    def _get(authed_client: TestClient) -> str:
+        resp = authed_client.get("/admin/csrf")
+        assert resp.status_code == 200, resp.text
+        return resp.json()["csrf_token"]
+
+    return _get

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,9 +298,10 @@ def seeded_client() -> Iterator[Callable[[dict[str, Any]], TestClient]]:
 
         test_client = TestClient(app, base_url="https://testserver")
         test_client.__enter__()
+        # Track immediately so teardown closes the client even if seeding fails.
+        clients.append(test_client)
         resp = test_client.get(_SEED_ROUTE)
         assert resp.status_code == 200, resp.text
-        clients.append(test_client)
         return test_client
 
     yield _make

--- a/tests/test_routes_admin.py
+++ b/tests/test_routes_admin.py
@@ -1,0 +1,58 @@
+"""Integration tests for admin auth gating and cache refresh.
+
+Exercises the full dependency chain (``get_current_admin`` + ``verify_csrf_token``)
+through the real app, covering the 401/403/200 auth ladder and CSRF enforcement
+on ``POST /admin/cache/refresh``.
+"""
+
+from typing import Any, Callable
+
+from fastapi.testclient import TestClient
+
+
+def test_admin_dashboard_401_anonymous(client: TestClient) -> None:
+    resp = client.get("/admin")
+    assert resp.status_code == 401
+
+
+def test_admin_dashboard_403_wrong_user(
+    seeded_client: Callable[[dict[str, Any]], TestClient],
+) -> None:
+    """A logged-in user who is not in ADMIN_USERS gets 403, not 401."""
+    wrong = seeded_client({"user": {"login": "not-an-admin"}})
+    resp = wrong.get("/admin")
+    assert resp.status_code == 403
+
+
+def test_admin_dashboard_200_admin(admin_client: TestClient) -> None:
+    resp = admin_client.get("/admin")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_cache_refresh_admin_with_csrf_succeeds(
+    admin_client: TestClient,
+    csrf_token: Callable[[TestClient], str],
+) -> None:
+    token = csrf_token(admin_client)
+    resp = admin_client.post("/admin/cache/refresh", headers={"X-CSRF-Token": token})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert set(body) == {"status", "cleared", "warmed", "duration_ms"}
+    assert isinstance(body["cleared"], int)
+    assert isinstance(body["warmed"], int)
+    assert isinstance(body["duration_ms"], (int, float))
+
+
+def test_cache_refresh_without_csrf_token_403(admin_client: TestClient) -> None:
+    """Authenticated admin omitting the CSRF token is rejected by
+    ``verify_csrf_token`` with 403."""
+    resp = admin_client.post("/admin/cache/refresh")
+    assert resp.status_code == 403
+
+
+def test_cache_refresh_anonymous_401(client: TestClient) -> None:
+    """Anonymous caller hits the auth dependency (401) before CSRF (403)."""
+    resp = client.post("/admin/cache/refresh")
+    assert resp.status_code == 401

--- a/tests/test_routes_pages.py
+++ b/tests/test_routes_pages.py
@@ -1,0 +1,42 @@
+"""Integration tests for the catch-all /{slug} page route.
+
+Confirms public pages render, unknown/hidden pages 404, and that a 404 with an
+HTML ``Accept`` header is served as the themed HTML 404 page by the custom
+exception handler in ``main.py``.
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_get_page_ok(client: TestClient) -> None:
+    resp = client.get("/about")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "About" in resp.text
+
+
+def test_get_page_404_unknown_slug(client: TestClient) -> None:
+    resp = client.get("/no-such-page")
+    assert resp.status_code == 404
+
+
+def test_hidden_page_returns_404(client: TestClient) -> None:
+    """``visibility: hidden`` pages 404 (pages.py:51), even though the file
+    exists in the content repo."""
+    resp = client.get("/secret")
+    assert resp.status_code == 404
+
+
+def test_html_404_returns_themed_html(client: TestClient) -> None:
+    """A 404 requested with ``Accept: text/html`` is rendered as the themed
+    HTML 404 page (main.py:140-148): status 404, content-type text/html."""
+    resp = client.get("/no-such-page", headers={"Accept": "text/html"})
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_404_json_for_non_html_accept(client: TestClient) -> None:
+    """Without an HTML Accept header the handler falls back to JSON."""
+    resp = client.get("/no-such-page", headers={"Accept": "application/json"})
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Page not found"}

--- a/tests/test_routes_posts.py
+++ b/tests/test_routes_posts.py
@@ -1,0 +1,79 @@
+"""Integration tests for the /posts routes.
+
+Driven through the real ``create_app()`` so pagination, draft gating, and the
+HTML 404 handler are all exercised end to end. Content comes from the in-memory
+``FakeGitHubService`` installed by the autouse fixture (five published posts,
+one draft, ``per_page=2``).
+"""
+
+from fastapi.testclient import TestClient
+
+
+def test_list_posts_ok_with_content(client: TestClient) -> None:
+    resp = client.get("/posts")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    # Newest two posts are on page 1 (per_page=2, newest-first by date).
+    assert "Post Five" in resp.text
+    assert "Post Four" in resp.text
+
+
+def test_list_posts_pagination_page_two(client: TestClient) -> None:
+    resp = client.get("/posts", params={"page": 2})
+    assert resp.status_code == 200
+    # Page 2 shows the next slice of published posts.
+    assert "Post Three" in resp.text
+    assert "Post Two" in resp.text
+    # Page-1 posts should not appear on page 2.
+    assert "Post Five" not in resp.text
+
+
+def test_list_posts_out_of_range_page_clamps(client: TestClient) -> None:
+    """The handler clamps ``page`` to ``total_pages`` (posts.py:44), so an
+    absurdly high page returns the last page (200), not an error."""
+    resp = client.get("/posts", params={"page": 999})
+    assert resp.status_code == 200
+    # Five published posts / per_page=2 => 3 pages; last page holds Post One.
+    assert "Post One" in resp.text
+
+
+def test_drafts_absent_for_anonymous(client: TestClient) -> None:
+    """Anonymous listing must never surface a draft, across all pages."""
+    seen_draft = False
+    for page in (1, 2, 3):
+        resp = client.get("/posts", params={"page": page})
+        assert resp.status_code == 200
+        if "Secret Draft" in resp.text:
+            seen_draft = True
+    assert not seen_draft
+
+
+def test_drafts_present_for_admin(admin_client: TestClient) -> None:
+    """Admins see drafts in the listing (include_drafts=True). With the draft
+    included there are 6 posts; the newest is the draft, so it lands on page 1."""
+    resp = admin_client.get("/posts")
+    assert resp.status_code == 200
+    assert "Secret Draft" in resp.text
+
+
+def test_get_post_ok_known_slug(client: TestClient) -> None:
+    resp = client.get("/posts/post-one")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "Post One" in resp.text
+
+
+def test_get_post_404_unknown_slug(client: TestClient) -> None:
+    resp = client.get("/posts/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_draft_detail_404_for_anonymous(client: TestClient) -> None:
+    resp = client.get("/posts/secret-draft")
+    assert resp.status_code == 404
+
+
+def test_draft_detail_200_for_admin(admin_client: TestClient) -> None:
+    resp = admin_client.get("/posts/secret-draft")
+    assert resp.status_code == 200
+    assert "Secret Draft" in resp.text

--- a/tests/test_routes_webhooks.py
+++ b/tests/test_routes_webhooks.py
@@ -1,0 +1,100 @@
+"""Integration tests for POST /webhooks/github.
+
+Covers HMAC-SHA256 signature verification, the missing-signature and
+invalid-signature paths, the non-push "ignored" response, and the
+unconfigured-secret behaviour.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.config import get_settings
+
+WEBHOOK_SECRET = "test-webhook-secret"  # matches the autouse fixture
+
+
+def _sign(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def test_valid_push_returns_ok(client: TestClient) -> None:
+    body = b'{"ref": "refs/heads/main"}'
+    resp = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": _sign(body),
+            "X-GitHub-Event": "push",
+            "Content-Type": "application/json",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["status"] == "ok"
+    assert "cleared" in payload
+    assert "warmed" in payload
+
+
+def test_invalid_signature_returns_401(client: TestClient) -> None:
+    body = b'{"ref": "refs/heads/main"}'
+    resp = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": "sha256=deadbeef",
+            "X-GitHub-Event": "push",
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_missing_signature_returns_401(client: TestClient) -> None:
+    body = b'{"ref": "refs/heads/main"}'
+    resp = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={"X-GitHub-Event": "push"},
+    )
+    assert resp.status_code == 401
+
+
+def test_non_push_event_is_ignored(client: TestClient) -> None:
+    """A correctly-signed non-push event short-circuits with an
+    ``{"status": "ignored", "event": ...}`` response (webhooks.py:64-65)."""
+    body = b'{"zen": "Keep it simple."}'
+    resp = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": _sign(body),
+            "X-GitHub-Event": "ping",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"status": "ignored", "event": "ping"}
+
+
+def test_unconfigured_secret_returns_500(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no webhook secret configured the route raises 500
+    (webhooks.py:42-46). Override the env the autouse fixture set, then
+    reload settings so the change takes effect for this request."""
+    monkeypatch.delenv("GITHUB_WEBHOOK_SECRET", raising=False)
+    get_settings.cache_clear()
+
+    body = b'{"ref": "refs/heads/main"}'
+    resp = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-Hub-Signature-256": _sign(body),
+            "X-GitHub-Event": "push",
+        },
+    )
+    assert resp.status_code == 500


### PR DESCRIPTION
Part of #61 (core-priority half — does not close it; a follow-up PR covers feed/seo/static/auth-flow/analytics/notes-CRUD)

## What

First integration-test layer over the real `create_app()` (lifespan, SessionMiddleware, custom HTML 404 handler) — 25 new tests, no `src/` changes, no existing test modified.

- **`tests/conftest.py`** — dict-backed `FakeGitHubService` matching the real coroutine signatures; default content (5 published posts + 1 draft, `per_page=2`, public + hidden pages, favicon) overridable via a `make_content` factory; an autouse fixture that pins env vars + resets every process-global singleton (`get_settings` cache, content cache, markdown service, theme engine) per test and installs the fake as the module-global GitHub service.
- **`test_routes_posts.py`** (9) — listing, pagination incl. out-of-range clamping, draft gating anon vs admin, detail 200/404, draft detail 404-anon/200-admin.
- **`test_routes_pages.py`** (5) — page 200/404, `visibility: hidden` → 404, themed HTML 404 via Accept header, JSON 404 fallback.
- **`test_routes_admin.py`** (6) — 401 anonymous / 403 wrong user / 200 admin; cache refresh with CSRF, without CSRF (403), anonymous (401).
- **`test_routes_webhooks.py`** (5) — valid HMAC push → ok, invalid/missing signature → 401, non-push event → ignored, unconfigured secret → 500.

## Notable implementation details

- **`https://testserver` base URL for session clients** — with `DEBUG=false` the app sets `SessionMiddleware(https_only=True)`, so the session cookie only flows over a secure scheme.
- **Env-pinning is scoped to the four integration modules** (via `request.module`), because `test_config.py` builds a bare `Settings()` and asserts env-derived defaults; the singleton resets run for every test and are side-effect free.
- File-based tmp SQLite rather than `:memory:` — the async pool's separate connections would each get their own empty in-memory DB.

## Verified

`python scripts/run-checks.py` 4/4 — full suite 266 passed (241 pre-existing + 25 new), ruff, pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)