### PR TITLE
feat(content): add post series support via frontmatter

### DIFF
--- a/.claude/skills/theme-creator/references/template-variables.md
+++ b/.claude/skills/theme-creator/references/template-variables.md
@@ -34,7 +34,7 @@
 
 ## Series context (post.html only)
 
-Present only when the post belongs to a series. Guard rendering with `{% if post.series %}` and treat the rest defensively. All sort by `series_order` (nulls last), then date.
+These five variables are **always present** in the post-template context, but they are all `None` when the post does not belong to a series. Theme authors must therefore guard rendering with `{% if post.series %}` and treat the individual variables defensively. Lists sort by `series_order` (nulls last), then date.
 
 | Variable | Type | Description |
 |----------|------|-------------|

--- a/.claude/skills/theme-creator/references/template-variables.md
+++ b/.claude/skills/theme-creator/references/template-variables.md
@@ -17,7 +17,7 @@
 | Template | Additional Variables |
 |----------|---------------------|
 | `index.html` | `posts` (list[Post]), `pagination` (Pagination), `notes` (list) |
-| `post.html` | `post` (Post), `notes` (list) |
+| `post.html` | `post` (Post), `notes` (list), series context (see below) |
 | `page.html` | `page` (Page), `notes` (list) |
 | `404.html` | Global context only |
 | `admin/admin.html` | `user` (dict), `analytics` (dict), `notes` (list[NoteResponse]), `cache_size` (int) |
@@ -29,3 +29,17 @@
 - `post.toc` — auto-generated table-of-contents HTML (a `<div class="toc">` wrapping a nested `<ul>`). Empty string when the post has no headings, or when the post sets `toc: false` in frontmatter. Themes opt in to render it; the three bundled themes show three different treatments (inline card, `<details>` collapsible, floating sidebar) — use them as references.
 - `post.reading_time` — string like `"3 min read"`.
 - `post.url` — canonical URL path (`/posts/<slug>`).
+- `post.series` — series/collection name from frontmatter (`series: "My Series"`), or `None`. Posts sharing the same (case-sensitive) name are grouped into an ordered series.
+- `post.series_order` — integer position within the series from frontmatter (`series_order: 2`); lower sorts first, `None`/unordered sorts last (date breaks ties). Malformed values coerce to `None`.
+
+## Series context (post.html only)
+
+Present only when the post belongs to a series. Guard rendering with `{% if post.series %}` and treat the rest defensively. All sort by `series_order` (nulls last), then date.
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `series_posts` | `list[Post] \| None` | All posts in the series, ordered. Drafts are included only for admins. |
+| `series_index` | `int \| None` | 1-based position of the current post in the series. |
+| `series_total` | `int \| None` | Total number of posts in the series. |
+| `series_prev` | `Post \| None` | Previous post in the series (`None` on the first post). |
+| `series_next` | `Post \| None` | Next post in the series (`None` on the last post). |

--- a/src/squishmark/models/content.py
+++ b/src/squishmark/models/content.py
@@ -27,6 +27,8 @@ class FrontMatter(BaseModel):
     visibility: Literal["public", "unlisted", "hidden"] = "public"
     nav_order: int | None = None  # Explicit ordering for navbar
     toc: bool = True  # Per-post opt-out for auto-generated table of contents
+    series: str | None = None  # Series/collection name this post belongs to
+    series_order: int | None = None  # Position within the series (lower = first)
 
     # Allow extra fields for extensibility
     model_config = {"extra": "allow"}
@@ -55,6 +57,33 @@ class FrontMatter(BaseModel):
                 return False
         return True  # unrecognized type/value — fall back to default
 
+    @field_validator("series_order", mode="before")
+    @classmethod
+    def _coerce_series_order(cls, v: Any) -> Any:
+        """Coerce null / empty / malformed values to None.
+
+        YAML allows ``series_order: null``, ``series_order:`` (empty), and
+        arbitrary strings. Pydantic's strict int parser rejects non-numeric
+        strings with ValidationError, which would crash the post-loading path
+        (a 500) for a stylistic frontmatter field. Treat anything that isn't a
+        clean integer as "unordered" (None) and move on.
+        """
+        if v is None or v == "":
+            return None
+        if isinstance(v, bool):
+            return None  # bool is an int subclass; reject True/False as garbage
+        if isinstance(v, int):
+            return v
+        if isinstance(v, float):
+            return int(v)
+        if isinstance(v, str):
+            stripped = v.strip()
+            try:
+                return int(stripped)
+            except ValueError:
+                return None
+        return None  # unrecognized type/value — treat as unordered
+
 
 class Post(BaseModel):
     """A blog post with parsed content."""
@@ -74,6 +103,8 @@ class Post(BaseModel):
     theme: str | None = None  # Per-page theme override
     author: str | None = None  # Per-post author override
     image: str | None = None  # Featured image URL (used for og:image)
+    series: str | None = None  # Series/collection name this post belongs to
+    series_order: int | None = None  # Position within the series (lower = first)
 
     @property
     def url(self) -> str:

--- a/src/squishmark/models/content.py
+++ b/src/squishmark/models/content.py
@@ -1,6 +1,7 @@
 """Pydantic models for content (posts, pages, config)."""
 
 import datetime
+import math
 import re
 from typing import Any, Literal
 
@@ -75,7 +76,9 @@ class FrontMatter(BaseModel):
         if isinstance(v, int):
             return v
         if isinstance(v, float):
-            return int(v)
+            # YAML parses `.nan` / `.inf` to non-finite floats; int() on those
+            # raises (ValueError/OverflowError) — treat them as garbage.
+            return int(v) if math.isfinite(v) else None
         if isinstance(v, str):
             stripped = v.strip()
             try:

--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -1,5 +1,7 @@
 """Routes for blog posts."""
 
+import datetime
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -96,8 +98,47 @@ async def get_post(
     # Featured posts for template context
     featured = get_featured_posts(all_posts, config.site)
 
+    # Build series navigation context if this post belongs to a series.
+    # all_posts is already draft-gated by include_drafts, so drafts are
+    # automatically excluded for non-admins.
+    series_posts: list | None = None
+    series_prev = None
+    series_next = None
+    series_index: int | None = None
+    series_total: int | None = None
+    if post.series:
+        series_posts = sorted(
+            (p for p in all_posts if p.series == post.series),
+            key=lambda p: (
+                p.series_order is None,
+                p.series_order if p.series_order is not None else 0,
+                p.date or datetime.date.min,
+            ),
+        )
+        series_total = len(series_posts)
+        current_idx = next(
+            (i for i, p in enumerate(series_posts) if p.slug == post.slug),
+            None,
+        )
+        if current_idx is not None:
+            series_index = current_idx + 1
+            if current_idx > 0:
+                series_prev = series_posts[current_idx - 1]
+            if current_idx < len(series_posts) - 1:
+                series_next = series_posts[current_idx + 1]
+
     # Render
     theme_engine = await get_theme_engine(github_service)
-    html = await theme_engine.render_post(config, post, notes, featured_posts=featured)
+    html = await theme_engine.render_post(
+        config,
+        post,
+        notes,
+        featured_posts=featured,
+        series_posts=series_posts,
+        series_prev=series_prev,
+        series_next=series_next,
+        series_index=series_index,
+        series_total=series_total,
+    )
 
     return HTMLResponse(content=html)

--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -1,7 +1,5 @@
 """Routes for blog posts."""
 
-import datetime
-
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from squishmark.dependencies import is_admin
 from squishmark.models.content import Config, Pagination
 from squishmark.models.db import get_db_session
-from squishmark.services.content import get_all_posts, get_featured_posts
+from squishmark.services.content import build_series_context, get_all_posts, get_featured_posts
 from squishmark.services.github import get_github_service
 from squishmark.services.markdown import get_markdown_service
 from squishmark.services.notes import NotesService
@@ -98,34 +96,9 @@ async def get_post(
     # Featured posts for template context
     featured = get_featured_posts(all_posts, config.site)
 
-    # Build series navigation context if this post belongs to a series.
-    # all_posts is already draft-gated by include_drafts, so drafts are
-    # automatically excluded for non-admins.
-    series_posts: list | None = None
-    series_prev = None
-    series_next = None
-    series_index: int | None = None
-    series_total: int | None = None
-    if post.series:
-        series_posts = sorted(
-            (p for p in all_posts if p.series == post.series),
-            key=lambda p: (
-                p.series_order is None,
-                p.series_order if p.series_order is not None else 0,
-                p.date or datetime.date.min,
-            ),
-        )
-        series_total = len(series_posts)
-        current_idx = next(
-            (i for i, p in enumerate(series_posts) if p.slug == post.slug),
-            None,
-        )
-        if current_idx is not None:
-            series_index = current_idx + 1
-            if current_idx > 0:
-                series_prev = series_posts[current_idx - 1]
-            if current_idx < len(series_posts) - 1:
-                series_next = series_posts[current_idx + 1]
+    # Series navigation context. all_posts is already draft-gated by
+    # include_drafts, so drafts are automatically excluded for non-admins.
+    series_context = build_series_context(post, all_posts)
 
     # Render
     theme_engine = await get_theme_engine(github_service)
@@ -134,11 +107,7 @@ async def get_post(
         post,
         notes,
         featured_posts=featured,
-        series_posts=series_posts,
-        series_prev=series_prev,
-        series_next=series_next,
-        series_index=series_index,
-        series_total=series_total,
+        **series_context,
     )
 
     return HTMLResponse(content=html)

--- a/src/squishmark/services/content.py
+++ b/src/squishmark/services/content.py
@@ -1,5 +1,8 @@
 """Shared content helpers for fetching and filtering posts and pages."""
 
+import datetime
+from typing import Any
+
 from squishmark.models.content import Page, Post, SiteConfig
 from squishmark.services.github import GitHubService
 from squishmark.services.markdown import MarkdownService
@@ -51,6 +54,54 @@ def get_featured_posts(posts: list[Post], site_config: SiteConfig) -> list[Post]
         ),
     )
     return featured[: site_config.featured_max]
+
+
+def build_series_context(post: Post, all_posts: list[Post]) -> dict[str, Any]:
+    """Build the series-navigation template context for a post.
+
+    Returns a dict whose keys match ``ThemeEngine.render_post``'s series
+    kwargs (``series_posts``, ``series_prev``, ``series_next``,
+    ``series_index``, ``series_total``) so callers can splat it directly.
+    All values are None when the post does not belong to a series.
+
+    ``all_posts`` is expected to be already draft-gated by the caller
+    (``get_all_posts(..., include_drafts=...)``), so drafts are excluded
+    from series navigation for non-admins automatically.
+
+    Series posts sort by ``series_order`` ascending (nulls last), then date.
+    """
+    series_posts: list[Post] | None = None
+    series_prev: Post | None = None
+    series_next: Post | None = None
+    series_index: int | None = None
+    series_total: int | None = None
+    if post.series:
+        series_posts = sorted(
+            (p for p in all_posts if p.series == post.series),
+            key=lambda p: (
+                p.series_order is None,
+                p.series_order if p.series_order is not None else 0,
+                p.date or datetime.date.min,
+            ),
+        )
+        series_total = len(series_posts)
+        current_idx = next(
+            (i for i, p in enumerate(series_posts) if p.slug == post.slug),
+            None,
+        )
+        if current_idx is not None:
+            series_index = current_idx + 1
+            if current_idx > 0:
+                series_prev = series_posts[current_idx - 1]
+            if current_idx < len(series_posts) - 1:
+                series_next = series_posts[current_idx + 1]
+    return {
+        "series_posts": series_posts,
+        "series_prev": series_prev,
+        "series_next": series_next,
+        "series_index": series_index,
+        "series_total": series_total,
+    }
 
 
 async def get_all_pages(

--- a/src/squishmark/services/markdown.py
+++ b/src/squishmark/services/markdown.py
@@ -206,6 +206,8 @@ class MarkdownService:
             theme=frontmatter.theme,
             author=frontmatter.author,
             image=frontmatter.image,
+            series=frontmatter.series,
+            series_order=frontmatter.series_order,
         )
 
     def parse_page(self, path: str, content: str) -> Page:

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -230,6 +230,11 @@ class ThemeEngine:
         notes: list[Any] | None = None,
         theme_override: str | None = None,
         featured_posts: list[Post] | None = None,
+        series_posts: list[Post] | None = None,
+        series_prev: Post | None = None,
+        series_next: Post | None = None,
+        series_index: int | None = None,
+        series_total: int | None = None,
     ) -> str:
         """Render a single post page."""
         template_name = post.template or "post.html"
@@ -242,6 +247,11 @@ class ThemeEngine:
             post=post,
             notes=notes or [],
             featured_posts=featured_posts or [],
+            series_posts=series_posts,
+            series_prev=series_prev,
+            series_next=series_next,
+            series_index=series_index,
+            series_total=series_total,
         )
 
     async def render_page(

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -1,0 +1,276 @@
+"""Tests for post series/collections support.
+
+Self-contained: uses direct calls plus MagicMock, no conftest.py. Mirrors the
+style of tests/test_posts.py.
+"""
+
+import datetime
+
+import pytest
+
+from squishmark.models.content import FrontMatter, Post
+from squishmark.services.content import get_all_posts
+from squishmark.services.markdown import MarkdownService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _series_context(post: Post, all_posts: list[Post]) -> dict:
+    """Replicate the router's series-context computation.
+
+    Kept in lockstep with ``get_post`` in routers/posts.py. ``all_posts`` is
+    assumed already draft-gated by the caller.
+    """
+    if not post.series:
+        return {
+            "series_posts": None,
+            "series_prev": None,
+            "series_next": None,
+            "series_index": None,
+            "series_total": None,
+        }
+    series_posts = sorted(
+        (p for p in all_posts if p.series == post.series),
+        key=lambda p: (
+            p.series_order is None,
+            p.series_order if p.series_order is not None else 0,
+            p.date or datetime.date.min,
+        ),
+    )
+    total = len(series_posts)
+    idx = next((i for i, p in enumerate(series_posts) if p.slug == post.slug), None)
+    prev_post = None
+    next_post = None
+    index = None
+    if idx is not None:
+        index = idx + 1
+        if idx > 0:
+            prev_post = series_posts[idx - 1]
+        if idx < len(series_posts) - 1:
+            next_post = series_posts[idx + 1]
+    return {
+        "series_posts": series_posts,
+        "series_prev": prev_post,
+        "series_next": next_post,
+        "series_index": index,
+        "series_total": total,
+    }
+
+
+def _post(slug: str, *, series: str | None = None, series_order=None, date=None) -> Post:
+    return Post(
+        slug=slug,
+        title=slug.replace("-", " ").title(),
+        series=series,
+        series_order=series_order,
+        date=date,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+class TestFrontMatterSeries:
+    """Series frontmatter parsing and series_order coercion."""
+
+    def test_series_present(self):
+        fm = FrontMatter(series="My Series", series_order=2)
+        assert fm.series == "My Series"
+        assert fm.series_order == 2
+
+    def test_series_absent(self):
+        fm = FrontMatter(title="No Series")
+        assert fm.series is None
+        assert fm.series_order is None
+
+    def test_series_order_null(self):
+        fm = FrontMatter(series="S", series_order=None)
+        assert fm.series_order is None
+
+    def test_series_order_empty_string(self):
+        fm = FrontMatter(series="S", series_order="")
+        assert fm.series_order is None
+
+    def test_series_order_numeric_string(self):
+        fm = FrontMatter(series="S", series_order="3")
+        assert fm.series_order == 3
+
+    def test_series_order_garbage_string(self):
+        """Malformed series_order must coerce to None, never raise."""
+        fm = FrontMatter(series="S", series_order="not-a-number")
+        assert fm.series_order is None
+
+    def test_series_order_garbage_list(self):
+        fm = FrontMatter(series="S", series_order=["bogus"])
+        assert fm.series_order is None
+
+    def test_series_order_bool_rejected(self):
+        # bool is an int subclass; treat as garbage rather than 0/1.
+        fm = FrontMatter(series="S", series_order=True)
+        assert fm.series_order is None
+
+    def test_series_order_float_truncated(self):
+        fm = FrontMatter(series="S", series_order=2.0)
+        assert fm.series_order == 2
+
+    def test_parse_post_threads_series(self):
+        md = MarkdownService()
+        content = "---\ntitle: T\nseries: My Series\nseries_order: 1\n---\nBody"
+        post = md.parse_post("posts/2026-01-01-t.md", content)
+        assert post.series == "My Series"
+        assert post.series_order == 1
+
+    def test_parse_post_garbage_series_order_does_not_raise(self):
+        md = MarkdownService()
+        content = "---\ntitle: T\nseries: My Series\nseries_order: nope\n---\nBody"
+        post = md.parse_post("posts/2026-01-01-t.md", content)
+        assert post.series == "My Series"
+        assert post.series_order is None
+
+    def test_parse_post_no_series(self):
+        md = MarkdownService()
+        post = md.parse_post("posts/2026-01-01-t.md", "---\ntitle: T\n---\nBody")
+        assert post.series is None
+        assert post.series_order is None
+
+
+# ---------------------------------------------------------------------------
+# Series sorting
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesSorting:
+    """Ordering of series_posts."""
+
+    def test_sorted_by_series_order(self):
+        posts = [
+            _post("c", series="S", series_order=3),
+            _post("a", series="S", series_order=1),
+            _post("b", series="S", series_order=2),
+        ]
+        ctx = _series_context(posts[0], posts)
+        assert [p.slug for p in ctx["series_posts"]] == ["a", "b", "c"]
+
+    def test_date_tiebreak_when_same_order(self):
+        posts = [
+            _post("late", series="S", series_order=1, date=datetime.date(2026, 2, 1)),
+            _post("early", series="S", series_order=1, date=datetime.date(2026, 1, 1)),
+        ]
+        ctx = _series_context(posts[0], posts)
+        assert [p.slug for p in ctx["series_posts"]] == ["early", "late"]
+
+    def test_none_order_sorts_last(self):
+        posts = [
+            _post("unordered", series="S", series_order=None, date=datetime.date(2026, 1, 1)),
+            _post("first", series="S", series_order=1, date=datetime.date(2026, 5, 1)),
+        ]
+        ctx = _series_context(posts[0], posts)
+        assert [p.slug for p in ctx["series_posts"]] == ["first", "unordered"]
+
+    def test_only_same_series_included(self):
+        posts = [
+            _post("a", series="S", series_order=1),
+            _post("other", series="Different", series_order=1),
+            _post("b", series="S", series_order=2),
+        ]
+        ctx = _series_context(posts[0], posts)
+        assert [p.slug for p in ctx["series_posts"]] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Prev/next boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesNavigation:
+    """series_prev / series_next / index / total."""
+
+    def _three(self):
+        return [
+            _post("p1", series="S", series_order=1),
+            _post("p2", series="S", series_order=2),
+            _post("p3", series="S", series_order=3),
+        ]
+
+    def test_first_post_has_no_prev(self):
+        posts = self._three()
+        ctx = _series_context(posts[0], posts)
+        assert ctx["series_prev"] is None
+        assert ctx["series_next"].slug == "p2"
+        assert ctx["series_index"] == 1
+        assert ctx["series_total"] == 3
+
+    def test_middle_post_has_both(self):
+        posts = self._three()
+        ctx = _series_context(posts[1], posts)
+        assert ctx["series_prev"].slug == "p1"
+        assert ctx["series_next"].slug == "p3"
+        assert ctx["series_index"] == 2
+
+    def test_last_post_has_no_next(self):
+        posts = self._three()
+        ctx = _series_context(posts[2], posts)
+        assert ctx["series_prev"].slug == "p2"
+        assert ctx["series_next"] is None
+        assert ctx["series_index"] == 3
+
+    def test_post_without_series_has_no_context(self):
+        posts = [_post("solo")]
+        ctx = _series_context(posts[0], posts)
+        assert ctx["series_posts"] is None
+        assert ctx["series_prev"] is None
+        assert ctx["series_next"] is None
+        assert ctx["series_index"] is None
+        assert ctx["series_total"] is None
+
+
+# ---------------------------------------------------------------------------
+# Draft gating (relies on get_all_posts draft filtering)
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesDraftGating:
+    """Drafts excluded from series for non-admins, included for admins."""
+
+    def _mock_github(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_github = AsyncMock()
+        mock_github.list_directory.return_value = [
+            "posts/2026-01-01-p1.md",
+            "posts/2026-01-02-p2.md",
+            "posts/2026-01-03-p3.md",
+        ]
+        mock_github.get_file.side_effect = [
+            MagicMock(content="---\ntitle: P1\ndate: 2026-01-01\nseries: S\nseries_order: 1\n---\nB"),
+            MagicMock(content="---\ntitle: P2\ndate: 2026-01-02\nseries: S\nseries_order: 2\ndraft: true\n---\nB"),
+            MagicMock(content="---\ntitle: P3\ndate: 2026-01-03\nseries: S\nseries_order: 3\n---\nB"),
+        ]
+        return mock_github
+
+    @pytest.mark.asyncio
+    async def test_draft_excluded_for_non_admin(self):
+        md = MarkdownService()
+        all_posts = await get_all_posts(self._mock_github(), md, include_drafts=False)
+        current = next(p for p in all_posts if p.slug == "p1")
+        ctx = _series_context(current, all_posts)
+        slugs = [p.slug for p in ctx["series_posts"]]
+        assert slugs == ["p1", "p3"]
+        assert ctx["series_total"] == 2
+        # p1's next skips the hidden draft and lands on p3
+        assert ctx["series_next"].slug == "p3"
+
+    @pytest.mark.asyncio
+    async def test_draft_included_for_admin(self):
+        md = MarkdownService()
+        all_posts = await get_all_posts(self._mock_github(), md, include_drafts=True)
+        current = next(p for p in all_posts if p.slug == "p1")
+        ctx = _series_context(current, all_posts)
+        slugs = [p.slug for p in ctx["series_posts"]]
+        assert slugs == ["p1", "p2", "p3"]
+        assert ctx["series_total"] == 3
+        assert ctx["series_next"].slug == "p2"

--- a/tests/test_series.py
+++ b/tests/test_series.py
@@ -9,54 +9,12 @@ import datetime
 import pytest
 
 from squishmark.models.content import FrontMatter, Post
-from squishmark.services.content import get_all_posts
+from squishmark.services.content import build_series_context, get_all_posts
 from squishmark.services.markdown import MarkdownService
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _series_context(post: Post, all_posts: list[Post]) -> dict:
-    """Replicate the router's series-context computation.
-
-    Kept in lockstep with ``get_post`` in routers/posts.py. ``all_posts`` is
-    assumed already draft-gated by the caller.
-    """
-    if not post.series:
-        return {
-            "series_posts": None,
-            "series_prev": None,
-            "series_next": None,
-            "series_index": None,
-            "series_total": None,
-        }
-    series_posts = sorted(
-        (p for p in all_posts if p.series == post.series),
-        key=lambda p: (
-            p.series_order is None,
-            p.series_order if p.series_order is not None else 0,
-            p.date or datetime.date.min,
-        ),
-    )
-    total = len(series_posts)
-    idx = next((i for i, p in enumerate(series_posts) if p.slug == post.slug), None)
-    prev_post = None
-    next_post = None
-    index = None
-    if idx is not None:
-        index = idx + 1
-        if idx > 0:
-            prev_post = series_posts[idx - 1]
-        if idx < len(series_posts) - 1:
-            next_post = series_posts[idx + 1]
-    return {
-        "series_posts": series_posts,
-        "series_prev": prev_post,
-        "series_next": next_post,
-        "series_index": index,
-        "series_total": total,
-    }
 
 
 def _post(slug: str, *, series: str | None = None, series_order=None, date=None) -> Post:
@@ -117,6 +75,34 @@ class TestFrontMatterSeries:
         fm = FrontMatter(series="S", series_order=2.0)
         assert fm.series_order == 2
 
+    def test_series_order_nan_float(self):
+        """float('nan') must coerce to None, not raise ValueError."""
+        fm = FrontMatter(series="S", series_order=float("nan"))
+        assert fm.series_order is None
+
+    def test_series_order_inf_float(self):
+        """float('inf') / float('-inf') must coerce to None, not raise OverflowError."""
+        fm = FrontMatter(series="S", series_order=float("inf"))
+        assert fm.series_order is None
+        fm = FrontMatter(series="S", series_order=float("-inf"))
+        assert fm.series_order is None
+
+    def test_parse_post_yaml_nan_series_order_does_not_raise(self):
+        """YAML `.nan` parses to float('nan') and must coerce to None."""
+        md = MarkdownService()
+        content = "---\ntitle: T\nseries: My Series\nseries_order: .nan\n---\nBody"
+        post = md.parse_post("posts/2026-01-01-t.md", content)
+        assert post.series == "My Series"
+        assert post.series_order is None
+
+    def test_parse_post_yaml_inf_series_order_does_not_raise(self):
+        """YAML `.inf` parses to float('inf') and must coerce to None."""
+        md = MarkdownService()
+        content = "---\ntitle: T\nseries: My Series\nseries_order: .inf\n---\nBody"
+        post = md.parse_post("posts/2026-01-01-t.md", content)
+        assert post.series == "My Series"
+        assert post.series_order is None
+
     def test_parse_post_threads_series(self):
         md = MarkdownService()
         content = "---\ntitle: T\nseries: My Series\nseries_order: 1\n---\nBody"
@@ -152,7 +138,7 @@ class TestSeriesSorting:
             _post("a", series="S", series_order=1),
             _post("b", series="S", series_order=2),
         ]
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert [p.slug for p in ctx["series_posts"]] == ["a", "b", "c"]
 
     def test_date_tiebreak_when_same_order(self):
@@ -160,7 +146,7 @@ class TestSeriesSorting:
             _post("late", series="S", series_order=1, date=datetime.date(2026, 2, 1)),
             _post("early", series="S", series_order=1, date=datetime.date(2026, 1, 1)),
         ]
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert [p.slug for p in ctx["series_posts"]] == ["early", "late"]
 
     def test_none_order_sorts_last(self):
@@ -168,7 +154,7 @@ class TestSeriesSorting:
             _post("unordered", series="S", series_order=None, date=datetime.date(2026, 1, 1)),
             _post("first", series="S", series_order=1, date=datetime.date(2026, 5, 1)),
         ]
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert [p.slug for p in ctx["series_posts"]] == ["first", "unordered"]
 
     def test_only_same_series_included(self):
@@ -177,7 +163,7 @@ class TestSeriesSorting:
             _post("other", series="Different", series_order=1),
             _post("b", series="S", series_order=2),
         ]
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert [p.slug for p in ctx["series_posts"]] == ["a", "b"]
 
 
@@ -198,7 +184,7 @@ class TestSeriesNavigation:
 
     def test_first_post_has_no_prev(self):
         posts = self._three()
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert ctx["series_prev"] is None
         assert ctx["series_next"].slug == "p2"
         assert ctx["series_index"] == 1
@@ -206,21 +192,21 @@ class TestSeriesNavigation:
 
     def test_middle_post_has_both(self):
         posts = self._three()
-        ctx = _series_context(posts[1], posts)
+        ctx = build_series_context(posts[1], posts)
         assert ctx["series_prev"].slug == "p1"
         assert ctx["series_next"].slug == "p3"
         assert ctx["series_index"] == 2
 
     def test_last_post_has_no_next(self):
         posts = self._three()
-        ctx = _series_context(posts[2], posts)
+        ctx = build_series_context(posts[2], posts)
         assert ctx["series_prev"].slug == "p2"
         assert ctx["series_next"] is None
         assert ctx["series_index"] == 3
 
     def test_post_without_series_has_no_context(self):
         posts = [_post("solo")]
-        ctx = _series_context(posts[0], posts)
+        ctx = build_series_context(posts[0], posts)
         assert ctx["series_posts"] is None
         assert ctx["series_prev"] is None
         assert ctx["series_next"] is None
@@ -257,7 +243,7 @@ class TestSeriesDraftGating:
         md = MarkdownService()
         all_posts = await get_all_posts(self._mock_github(), md, include_drafts=False)
         current = next(p for p in all_posts if p.slug == "p1")
-        ctx = _series_context(current, all_posts)
+        ctx = build_series_context(current, all_posts)
         slugs = [p.slug for p in ctx["series_posts"]]
         assert slugs == ["p1", "p3"]
         assert ctx["series_total"] == 2
@@ -269,7 +255,7 @@ class TestSeriesDraftGating:
         md = MarkdownService()
         all_posts = await get_all_posts(self._mock_github(), md, include_drafts=True)
         current = next(p for p in all_posts if p.slug == "p1")
-        ctx = _series_context(current, all_posts)
+        ctx = build_series_context(current, all_posts)
         slugs = [p.slug for p in ctx["series_posts"]]
         assert slugs == ["p1", "p2", "p3"]
         assert ctx["series_total"] == 3

--- a/themes/blue-tech/post.html
+++ b/themes/blue-tech/post.html
@@ -44,6 +44,21 @@
     </aside>
     {% endif %}
 
+    {% if post.series %}
+    <details class="post-series" open>
+        <summary>{{ post.series }}{% if series_index and series_total %} &middot; Part {{ series_index }} of {{ series_total }}{% endif %}</summary>
+        <ol class="post-series-list">
+            {% for p in series_posts %}
+            {% if p.slug == post.slug %}
+            <li class="post-series-current" aria-current="true">{{ p.title }}</li>
+            {% else %}
+            <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+            {% endif %}
+            {% endfor %}
+        </ol>
+    </details>
+    {% endif %}
+
     {% if post.toc %}
     <details class="post-toc">
         <summary>Contents</summary>
@@ -56,6 +71,16 @@
     </div>
 
     <footer class="post-footer">
+        {% if post.series and (series_prev or series_next) %}
+        <nav class="post-series-nav" aria-label="Series navigation">
+            {% if series_prev %}
+            <a href="{{ series_prev.url }}" class="post-series-link post-series-prev">&larr; {{ series_prev.title }}</a>
+            {% endif %}
+            {% if series_next %}
+            <a href="{{ series_next.url }}" class="post-series-link post-series-next">{{ series_next.title }} &rarr;</a>
+            {% endif %}
+        </nav>
+        {% endif %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -513,6 +513,99 @@ img {
 }
 
 /* ============================================
+   Post Series
+   ============================================ */
+.post-series {
+    margin: 1.5rem 0 2rem;
+    padding: 0.75rem 1rem;
+    background: rgba(59, 130, 246, 0.08);
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    border-radius: 6px;
+    font-size: 0.95rem;
+}
+
+.post-series > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-accent, #3b82f6);
+    list-style: none;
+    user-select: none;
+    border-radius: 2px;
+}
+
+.post-series > summary:focus-visible {
+    outline: 2px solid var(--color-accent, #3b82f6);
+    outline-offset: 3px;
+}
+
+.post-series > summary::-webkit-details-marker {
+    display: none;
+}
+
+.post-series > summary::before {
+    content: "▸ ";
+    display: inline-block;
+    transition: transform 0.15s ease;
+    margin-right: 0.25rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .post-series > summary::before {
+        transition: none;
+    }
+}
+
+.post-series[open] > summary::before {
+    transform: rotate(90deg);
+}
+
+.post-series-list {
+    margin: 0.75rem 0 0;
+    padding-left: 1.5rem;
+}
+
+.post-series-list li {
+    margin: 0.2rem 0;
+}
+
+.post-series-list a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.post-series-list a:hover {
+    color: var(--color-accent, #3b82f6);
+    text-decoration: underline;
+}
+
+.post-series-current {
+    color: var(--color-text-muted);
+    font-weight: 600;
+}
+
+.post-series-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.post-series-link {
+    color: var(--color-accent, #3b82f6);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.post-series-link:hover {
+    text-decoration: underline;
+}
+
+.post-series-next {
+    margin-left: auto;
+    text-align: right;
+}
+
+/* ============================================
    Post/Page Content
    ============================================ */
 .post-content, .page-content {

--- a/themes/default/post.html
+++ b/themes/default/post.html
@@ -44,6 +44,24 @@
     </aside>
     {% endif %}
 
+    {% if post.series %}
+    <aside class="post-series" aria-label="Post series">
+        <p class="post-series-title">{{ post.series }}</p>
+        {% if series_index and series_total %}
+        <p class="post-series-progress">Part {{ series_index }} of {{ series_total }}</p>
+        {% endif %}
+        <ol class="post-series-list">
+            {% for p in series_posts %}
+            {% if p.slug == post.slug %}
+            <li class="post-series-current" aria-current="true">{{ p.title }}</li>
+            {% else %}
+            <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+            {% endif %}
+            {% endfor %}
+        </ol>
+    </aside>
+    {% endif %}
+
     {% if post.toc %}
     <aside class="post-toc" aria-label="Table of contents">
         <p class="post-toc-title">Contents</p>
@@ -56,6 +74,16 @@
     </div>
 
     <footer class="post-footer">
+        {% if post.series and (series_prev or series_next) %}
+        <nav class="post-series-nav" aria-label="Series navigation">
+            {% if series_prev %}
+            <a href="{{ series_prev.url }}" class="post-series-link post-series-prev">&larr; {{ series_prev.title }}</a>
+            {% endif %}
+            {% if series_next %}
+            <a href="{{ series_next.url }}" class="post-series-link post-series-next">{{ series_next.title }} &rarr;</a>
+            {% endif %}
+        </nav>
+        {% endif %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/default/static/style.css
+++ b/themes/default/static/style.css
@@ -470,6 +470,77 @@ a:hover {
     text-decoration: underline;
 }
 
+/* Post series box */
+.post-series {
+    margin: 1.5rem 0 2rem;
+    padding: 1rem 1.25rem;
+    background: var(--color-accent-subtle-bg);
+    border-left: 3px solid var(--color-accent);
+    border-radius: 4px;
+    font-size: 0.95rem;
+}
+
+.post-series-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-accent);
+    margin: 0 0 0.25rem;
+}
+
+.post-series-progress {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem;
+}
+
+.post-series-list {
+    margin: 0;
+    padding-left: 1.4rem;
+}
+
+.post-series-list li {
+    margin: 0.15rem 0;
+}
+
+.post-series-list a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.post-series-list a:hover {
+    text-decoration: underline;
+}
+
+.post-series-current {
+    color: var(--color-text-muted);
+    font-weight: 600;
+}
+
+/* Post series prev/next navigation (footer) */
+.post-series-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: var(--spacing-unit);
+}
+
+.post-series-link {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.post-series-link:hover {
+    text-decoration: underline;
+}
+
+.post-series-next {
+    margin-left: auto;
+    text-align: right;
+}
+
 /* Post/page content */
 .post-content,
 .page-content {

--- a/themes/terminal/post.html
+++ b/themes/terminal/post.html
@@ -39,6 +39,21 @@
         {% endif %}
     </header>
 
+    {% if post.series %}
+    <aside class="post-series" aria-label="Post series">
+        <div class="post-series-label">// series: {{ post.series }}{% if series_index and series_total %} [{{ series_index }}/{{ series_total }}]{% endif %}</div>
+        <ol class="post-series-list">
+            {% for p in series_posts %}
+            {% if p.slug == post.slug %}
+            <li class="post-series-current" aria-current="true">{{ p.title }}</li>
+            {% else %}
+            <li><a href="{{ p.url }}">{{ p.title }}</a></li>
+            {% endif %}
+            {% endfor %}
+        </ol>
+    </aside>
+    {% endif %}
+
     {% if notes %}
     <aside class="notes">
         {% for note in notes %}
@@ -55,6 +70,16 @@
     </div>
 
     <footer class="post-footer">
+        {% if post.series and (series_prev or series_next) %}
+        <nav class="post-series-nav" aria-label="Series navigation">
+            {% if series_prev %}
+            <a href="{{ series_prev.url }}" class="post-series-link post-series-prev">&larr; {{ series_prev.title }}</a>
+            {% endif %}
+            {% if series_next %}
+            <a href="{{ series_next.url }}" class="post-series-link post-series-next">{{ series_next.title }} &rarr;</a>
+            {% endif %}
+        </nav>
+        {% endif %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/terminal/static/css/style.css
+++ b/themes/terminal/static/css/style.css
@@ -440,6 +440,86 @@ img {
     }
 }
 
+/* Post series box — inline within the article (unlike the fixed TOC card). */
+.post-series {
+    margin: 0 0 2.5rem;
+    padding: 1rem 1.1rem;
+    background: var(--color-bg-card);
+    border: 1px solid rgba(74, 222, 128, 0.35);
+    border-radius: 4px;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    line-height: 1.6;
+    text-align: left;
+}
+
+.post-series-label {
+    color: var(--color-green);
+    font-weight: 600;
+    margin-bottom: 0.6rem;
+    letter-spacing: 0.03em;
+    font-size: 0.8rem;
+    text-transform: lowercase;
+}
+
+.post-series-list {
+    margin: 0;
+    padding-left: 1rem;
+    list-style: none;
+    counter-reset: series;
+}
+
+.post-series-list li {
+    margin: 0.15rem 0;
+    position: relative;
+    counter-increment: series;
+}
+
+.post-series-list li::before {
+    content: counter(series) ".";
+    color: var(--color-blue);
+    margin-right: 0.4rem;
+}
+
+.post-series-list a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.post-series-list a:hover {
+    color: var(--color-green);
+    text-decoration: underline;
+}
+
+.post-series-current {
+    color: var(--color-text-muted);
+    font-weight: 600;
+}
+
+.post-series-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 2rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+}
+
+.post-series-link {
+    color: var(--color-blue);
+    text-decoration: none;
+}
+
+.post-series-link:hover {
+    color: var(--color-green);
+    text-decoration: underline;
+}
+
+.post-series-next {
+    margin-left: auto;
+    text-align: right;
+}
+
 .post-header, .page-header {
     text-align: center;
     margin-bottom: 3rem;

--- a/themes/terminal/static/css/style.css
+++ b/themes/terminal/static/css/style.css
@@ -453,13 +453,14 @@ img {
     text-align: left;
 }
 
+/* No text-transform here: the "// series:" prefix is already lowercase in the
+   template, and the user's series name must keep its original casing. */
 .post-series-label {
     color: var(--color-green);
     font-weight: 600;
     margin-bottom: 0.6rem;
     letter-spacing: 0.03em;
     font-size: 0.8rem;
-    text-transform: lowercase;
 }
 
 .post-series-list {


### PR DESCRIPTION
Closes #63

## What

Posts can now declare `series: "Name"` and `series_order: N` in frontmatter; post detail pages get full series navigation.

- **Models** — `series` / `series_order` on `FrontMatter` and `Post`, with a `mode="before"` coercion validator on `series_order` (mirrors the `toc` pattern): null/empty/garbage/bool → `None`, numeric strings → int, floats truncate. Malformed frontmatter can never 500 a route.
- **Router** — `get_post` builds series context from the already-draft-gated post list (drafts auto-excluded for non-admins): `series_posts` sorted by `series_order` (unordered last) with date tiebreak, 1-based `series_index`, `series_total`, `series_prev`/`series_next` (`None` at boundaries).
- **Theme engine** — `render_post` forwards the five series context variables.
- **All three themes** — a series box near the top (default: accent card; blue-tech: open `<details>`; terminal: `// series:` label) with the series name, "Part X of Y", and a linked list of all parts with the current one highlighted; prev/next links in the post footer. Everything guarded by `{% if post.series %}`.
- **Docs** — theme-creator `template-variables.md` updated.
- **Tests** — 22 new tests in a self-contained `tests/test_series.py` (parsing/coercion, ordering + tiebreaks, boundary prev/next, non-series posts unaffected, draft exclusion anon vs admin). Intentionally avoids `tests/conftest.py` to stay independent of #91.

## Verified

- `python scripts/run-checks.py` 4/4 (263 tests, ruff, pyright clean).
- Playwright across all three themes (default, blue-tech, terminal): mid-series shows full list + both prev/next; first/last posts show single nav link; non-series post renders zero series elements (DOM-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)