### PR TITLE
ci(commits): allow any casing in pr title subject

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -40,10 +40,8 @@ jobs:
           # Disable validation for merge commits
           ignoreLabels: |
             ignore-conventional-commits
-          # Configure validation
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            should start with a lowercase letter.
+          # No subjectPattern: any casing after the type(scope) prefix is fine.
+          # Dependabot titles its PRs "chore(deps): Bump ..." (capital B, not
+          # configurable), and we accept that style for human PRs too.
           # Whether the PR title should match the commit message format
           validateSingleCommit: false


### PR DESCRIPTION
## What

Removes `subjectPattern: ^(?![A-Z]).+$` (and its error message) from the conventional-commits check. The `type(scope): subject` structure stays enforced; only the lowercase-first-letter rule on the subject goes away.

## Why

Dependabot titles every PR `chore(deps): Bump …` / `chore(deps-dev): Update …` with a capital subject that is not configurable, so all five of its first PRs (#93–#97) fail `check-commits`. Per discussion, mixed casing after the conventional prefix is acceptable for human PRs too, so the rule is relaxed globally rather than special-casing the bot.

After this merges, the open Dependabot PRs get `@dependabot rebase` comments so the check re-evaluates against the relaxed config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)