### PR TITLE
style(scripts): adopt pep 758 unparenthesized except syntax

### DIFF
--- a/scripts/start-dev.py
+++ b/scripts/start-dev.py
@@ -49,7 +49,7 @@ def _read_registry() -> list[dict]:
         if not isinstance(servers, list):
             return []
         return servers
-    except (json.JSONDecodeError, TypeError, AttributeError):
+    except json.JSONDecodeError, TypeError, AttributeError:
         return []
 
 
@@ -115,7 +115,7 @@ def _kill_registered_pid(pid: int, servers: list[dict] | None = None) -> bool:
         else:
             os.kill(pid, signal.SIGTERM)
             return True
-    except (ProcessLookupError, PermissionError, OSError):
+    except ProcessLookupError, PermissionError, OSError:
         return False
 
 


### PR DESCRIPTION
## What

Reformats the two multi-exception `except (A, B, C):` clauses in `scripts/start-dev.py` to the PEP 758 unparenthesized form `except A, B, C:`.

## Why

Dependabot's ruff bump (#97, `>=0.14,<0.16`) fails `lint` because ruff 0.15's formatter rewrites these clauses under our `py314` target. Verified locally that current ruff 0.14.14 accepts the unparenthesized form too, so this lands cleanly under today's CI — after which #97 just needs a rebase to go green.

## Verified

`python scripts/run-checks.py` 4/4 (ruff format/check on 0.14.14, 267 tests, pyright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)