### PR TITLE
feat(search): add server-side search with navbar ui across themes

### DIFF
--- a/.claude/skills/theme-creator/references/static-files.md
+++ b/.claude/skills/theme-creator/references/static-files.md
@@ -10,6 +10,7 @@
 - Allowed extensions: `.ico` `.png` `.svg` `.jpg` `.jpeg` `.webp` `.gif` `.css` `.js`
 - Cache-Control: `public, max-age=86400` (1 day)
 - Theme static files fall back to the `default` theme if not found in the current theme
+- `search.js` (navbar search behavior) ships in `themes/default/static/` and reaches every theme through that fallback — request it as `/static/{{ theme_name }}/search.js`; a theme overrides behavior by shipping its own `static/search.js`
 
 ## Referencing Static Files in Templates
 

--- a/.claude/skills/theme-creator/references/template-variables.md
+++ b/.claude/skills/theme-creator/references/template-variables.md
@@ -43,3 +43,18 @@ These five variables are **always present** in the post-template context, but th
 | `series_total` | `int \| None` | Total number of posts in the series. |
 | `series_prev` | `Post \| None` | Previous post in the series (`None` on the first post). |
 | `series_next` | `Post \| None` | Next post in the series (`None` on the last post). |
+
+## Search component
+
+Navbar search is a shared partial + shared JS, adopted per theme:
+
+```jinja2
+{% set search_mode = "button" %}   {# or "input" #}
+{% include "_search.html" %}
+```
+
+- `button` mode: an icon button (`.search-toggle`) opens a dropdown containing the input and results (default, terminal).
+- `input` mode: the input sits inline in the navbar; the dropdown shows results only (blue-tech).
+- Behavior (debounced `GET /search?q=`, `Cmd/Ctrl+K`, Escape, click-outside, arrow keys) comes from `search.js` — load it with `<script src="/static/{{ theme_name }}/search.js" defer></script>` (resolves via the default-theme static fallback).
+- Themes must style the hooks: `.search`, `.search-toggle`, `.search-input`, `.search-dropdown`, `.search-results` (+ `.search-result-title/-meta/-draft/-excerpt`, `.search-empty`, and `li.is-active` for keyboard highlight). See the three bundled themes for reference treatments.
+- Override the markup per theme by shipping your own `_search.html`, or per site via `theme/_search.html` in the content repo; override behavior by shipping your own `static/search.js`.

--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -14,7 +14,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from squishmark.config import get_settings
 from squishmark.models.content import Config
 from squishmark.models.db import close_db, get_db_session, init_db
-from squishmark.routers import admin, auth, feed, pages, posts, seo, webhooks
+from squishmark.routers import admin, auth, feed, pages, posts, search, seo, webhooks
 from squishmark.services.analytics import AnalyticsService
 from squishmark.services.github import get_github_service, shutdown_github_service
 from squishmark.services.markdown import get_markdown_service
@@ -325,6 +325,7 @@ def create_app() -> FastAPI:
     app.include_router(webhooks.router)
     app.include_router(feed.router)
     app.include_router(seo.router)
+    app.include_router(search.router)
     app.include_router(posts.router)
     app.include_router(pages.router)  # Catch-all for static pages, must be last
 

--- a/src/squishmark/routers/search.py
+++ b/src/squishmark/routers/search.py
@@ -1,0 +1,35 @@
+"""Search route."""
+
+from fastapi import APIRouter, Query, Request
+from fastapi.responses import JSONResponse
+
+from squishmark.dependencies import is_admin
+from squishmark.services.search import (
+    DEFAULT_LIMIT,
+    MIN_QUERY_LENGTH,
+    get_search_index,
+    search_index,
+)
+
+router = APIRouter(tags=["search"])
+
+
+@router.get("/search")
+async def search(request: Request, q: str = Query("", max_length=200)) -> JSONResponse:
+    """Search posts by keyword; admins also match drafts.
+
+    Short or empty queries return an empty result set with 200 (the client
+    fires on every debounce tick — an error status would just be noise).
+    The response is never cacheable: it varies by session (drafts).
+    """
+    query = q.strip()
+    results: list[dict] = []
+
+    if len(query) >= MIN_QUERY_LENGTH:
+        index = await get_search_index(include_drafts=is_admin(request))
+        results = [r.model_dump(mode="json") for r in search_index(query, index, limit=DEFAULT_LIMIT)]
+
+    return JSONResponse(
+        content={"query": q, "results": results},
+        headers={"Cache-Control": "no-store"},
+    )

--- a/src/squishmark/routers/search.py
+++ b/src/squishmark/routers/search.py
@@ -30,6 +30,6 @@ async def search(request: Request, q: str = Query("", max_length=200)) -> JSONRe
         results = [r.model_dump(mode="json") for r in search_index(query, index, limit=DEFAULT_LIMIT)]
 
     return JSONResponse(
-        content={"query": q, "results": results},
+        content={"query": query, "results": results},
         headers={"Cache-Control": "no-store"},
     )

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from squishmark.config import get_settings
 from squishmark.services.cache import get_cache
 from squishmark.services.github import get_github_service
+from squishmark.services.search import warm_search_indexes
 from squishmark.services.theme import get_theme_engine, reset_theme_engine
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
@@ -89,6 +90,9 @@ async def github_webhook(request: Request) -> dict:
 
     # Reload theme engine
     await get_theme_engine(github_service)
+
+    # Pre-build both search index variants so the first search isn't cold
+    await warm_search_indexes()
 
     return {
         "status": "ok",

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -1,0 +1,182 @@
+"""Server-side post search: tokenization, indexing, and scoring.
+
+Pure and synchronous so the scoring logic is directly unit-testable
+(mirrors ``build_series_context`` in services/content.py). Draft gating is
+the caller's responsibility: index the post list appropriate for the
+audience (``get_all_posts(include_drafts=...)``); the scorer itself never
+filters drafts.
+"""
+
+import datetime
+import re
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from squishmark.models.content import Config, Post
+from squishmark.services.cache import get_cache
+from squishmark.services.content import get_all_posts
+from squishmark.services.github import get_github_service
+from squishmark.services.markdown import get_markdown_service
+
+MIN_QUERY_LENGTH = 2
+DEFAULT_LIMIT = 8
+
+# Audience-separated cache keys. The "all" index includes drafts and must
+# only ever be read for admin requests — sharing one key would leak draft
+# titles/excerpts to anonymous visitors. /search responses themselves are
+# never cached for the same reason.
+SEARCH_INDEX_PUBLISHED_KEY = "search:index:published"
+SEARCH_INDEX_ALL_KEY = "search:index:all"
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+# Presence-based weights per (field, tier). Exact beats prefix within a
+# field; title beats tags beats description beats body across fields. No
+# term frequency — long bodies must not outrank a title hit.
+_WEIGHTS = {
+    "title": (12, 8),
+    "tags": (10, 6),
+    "description": (5, 3),
+    "body": (2, 1),
+}
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase and split text into a set of word tokens.
+
+    Splits on anything outside [a-z0-9], so hyphenated and punctuated
+    terms match their parts ("blue-tech" -> {"blue", "tech"}).
+    """
+    return set(_WORD_RE.findall(text.lower()))
+
+
+class SearchResult(BaseModel):
+    """One search hit, shaped for the /search JSON response."""
+
+    title: str
+    url: str
+    date: datetime.date | None
+    tags: list[str]
+    excerpt: str
+    draft: bool
+
+
+@dataclass(frozen=True)
+class IndexedPost:
+    """A post pre-tokenized per field, with its result payload prebuilt."""
+
+    result: SearchResult
+    title_tokens: frozenset[str]
+    tag_tokens: frozenset[str]
+    description_tokens: frozenset[str]
+    body_tokens: frozenset[str]
+
+
+def build_search_index(posts: list[Post]) -> list[IndexedPost]:
+    """Tokenize posts once so per-query scoring is set lookups only."""
+    index: list[IndexedPost] = []
+    for post in posts:
+        index.append(
+            IndexedPost(
+                result=SearchResult(
+                    title=post.title,
+                    url=post.url,
+                    date=post.date,
+                    tags=post.tags,
+                    excerpt=post.description,
+                    draft=post.draft,
+                ),
+                title_tokens=frozenset(tokenize(post.title)),
+                tag_tokens=frozenset(tokenize(" ".join(post.tags))),
+                description_tokens=frozenset(tokenize(post.description)),
+                body_tokens=frozenset(tokenize(post.content)),
+            )
+        )
+    return index
+
+
+def _field_score(query_token: str, field_tokens: frozenset[str], exact_weight: int, prefix_weight: int) -> int:
+    """Score one query token against one field: exact tier wins over prefix."""
+    if query_token in field_tokens:
+        return exact_weight
+    if any(token.startswith(query_token) for token in field_tokens):
+        return prefix_weight
+    return 0
+
+
+def _score_post(query_tokens: list[str], indexed: IndexedPost) -> int:
+    """Sum field scores per query token; 0 when any token matches nothing (AND)."""
+    fields = (
+        (indexed.title_tokens, *_WEIGHTS["title"]),
+        (indexed.tag_tokens, *_WEIGHTS["tags"]),
+        (indexed.description_tokens, *_WEIGHTS["description"]),
+        (indexed.body_tokens, *_WEIGHTS["body"]),
+    )
+    total = 0
+    for query_token in query_tokens:
+        token_score = sum(
+            _field_score(query_token, field_tokens, exact, prefix) for field_tokens, exact, prefix in fields
+        )
+        if token_score == 0:
+            return 0
+        total += token_score
+    return total
+
+
+def search_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
+    """Rank indexed posts against the query; top ``limit`` results.
+
+    Every query token must match somewhere (exact or prefix) for a post to
+    qualify. Ties break by date descending, dateless posts last.
+    """
+    if len(query.strip()) < MIN_QUERY_LENGTH:
+        return []
+    query_tokens = sorted(tokenize(query))
+    if not query_tokens:
+        return []
+
+    scored = [(score, indexed) for indexed in index if (score := _score_post(query_tokens, indexed)) > 0]
+    scored.sort(
+        key=lambda pair: (
+            -pair[0],
+            pair[1].result.date is None,
+            -(pair[1].result.date.toordinal() if pair[1].result.date else 0),
+        ),
+    )
+    return [indexed.result for _, indexed in scored[:limit]]
+
+
+def search_posts(query: str, posts: list[Post], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
+    """Convenience: build an index and search it in one call."""
+    return search_index(query, build_search_index(posts), limit)
+
+
+async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
+    """Return the cached index for the audience, building it on miss.
+
+    Building is the expensive part (get_all_posts re-parses every post's
+    markdown); the index inherits the cache's TTL and is invalidated by
+    the webhook's cache.clear() like every other derived blob.
+    """
+    cache = get_cache()
+    key = SEARCH_INDEX_ALL_KEY if include_drafts else SEARCH_INDEX_PUBLISHED_KEY
+    cached = await cache.get(key)
+    if cached is not None:
+        return cached
+
+    github_service = get_github_service()
+    config_data = await github_service.get_config()
+    config = Config.from_dict(config_data)
+    markdown_service = get_markdown_service(config)
+    posts = await get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
+
+    index = build_search_index(posts)
+    await cache.set(key, index)
+    return index
+
+
+async def warm_search_indexes() -> None:
+    """Pre-build both audience index variants (used by the webhook warm)."""
+    await get_search_index(include_drafts=False)
+    await get_search_index(include_drafts=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,7 @@ _INTEGRATION_MODULES = (
     "test_routes_pages",
     "test_routes_admin",
     "test_routes_webhooks",
+    "test_routes_search",
 )
 
 

--- a/tests/test_routes_search.py
+++ b/tests/test_routes_search.py
@@ -1,0 +1,89 @@
+"""Integration tests for GET /search.
+
+Driven through the real ``create_app()``; content comes from the
+``FakeGitHubService`` installed by the autouse fixture (five published
+posts "Post One".."Post Five" + the draft "Secret Draft"). Also guards the
+draft-leak property: the cached search index is audience-separated, so an
+admin search must never poison anonymous results (and vice versa).
+"""
+
+from fastapi.testclient import TestClient
+
+RESULT_KEYS = {"title", "url", "date", "tags", "excerpt", "draft"}
+
+
+def test_search_returns_json_results(client: TestClient) -> None:
+    """Also proves the route isn't swallowed by the pages catch-all,
+    which would return an HTML 404 instead of JSON."""
+    resp = client.get("/search", params={"q": "post"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.headers["cache-control"] == "no-store"
+    body = resp.json()
+    assert body["query"] == "post"
+    assert len(body["results"]) == 5
+    for result in body["results"]:
+        assert set(result) == RESULT_KEYS
+    assert body["results"][0]["url"].startswith("/posts/")
+
+
+def test_search_draft_hidden_for_anonymous(client: TestClient) -> None:
+    resp = client.get("/search", params={"q": "secret"})
+    assert resp.status_code == 200
+    assert resp.json()["results"] == []
+
+
+def test_search_draft_flagged_for_admin(admin_client: TestClient) -> None:
+    resp = admin_client.get("/search", params={"q": "secret"})
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["title"] == "Secret Draft"
+    assert results[0]["url"] == "/posts/secret-draft"
+    assert results[0]["draft"] is True
+
+
+def test_search_empty_query_returns_empty(client: TestClient) -> None:
+    resp = client.get("/search")
+    assert resp.status_code == 200
+    assert resp.json() == {"query": "", "results": []}
+
+
+def test_search_short_query_returns_empty(client: TestClient) -> None:
+    resp = client.get("/search", params={"q": "p"})
+    assert resp.status_code == 200
+    assert resp.json()["results"] == []
+
+
+def test_search_no_match_returns_empty(client: TestClient) -> None:
+    resp = client.get("/search", params={"q": "zzzznomatch"})
+    assert resp.status_code == 200
+    assert resp.json()["results"] == []
+
+
+def test_admin_search_does_not_poison_anonymous_results(
+    admin_client: TestClient,
+    client: TestClient,
+) -> None:
+    """Admin searches first (builds the drafts-included index), then an
+    anonymous search must still exclude drafts."""
+    admin_resp = admin_client.get("/search", params={"q": "secret"})
+    assert len(admin_resp.json()["results"]) == 1
+
+    anon_resp = client.get("/search", params={"q": "secret"})
+    assert anon_resp.json()["results"] == []
+
+
+def test_anonymous_search_does_not_hide_drafts_from_admin(
+    client: TestClient,
+    admin_client: TestClient,
+) -> None:
+    """Anonymous searches first (builds the published-only index), then an
+    admin search must still include drafts."""
+    anon_resp = client.get("/search", params={"q": "secret"})
+    assert anon_resp.json()["results"] == []
+
+    admin_resp = admin_client.get("/search", params={"q": "secret"})
+    results = admin_resp.json()["results"]
+    assert len(results) == 1
+    assert results[0]["draft"] is True

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,166 @@
+"""Tests for the search service (tokenization, indexing, scoring).
+
+Self-contained pure-function tests against services/search.py, mirroring
+the style of tests/test_series.py.
+"""
+
+import datetime
+
+from squishmark.models.content import Post
+from squishmark.services.search import (
+    DEFAULT_LIMIT,
+    build_search_index,
+    search_index,
+    search_posts,
+    tokenize,
+)
+
+
+def _post(
+    slug: str,
+    *,
+    title: str | None = None,
+    tags: list[str] | None = None,
+    description: str = "",
+    content: str = "",
+    date: datetime.date | None = None,
+    draft: bool = False,
+) -> Post:
+    return Post(
+        slug=slug,
+        title=title if title is not None else slug.replace("-", " ").title(),
+        tags=tags or [],
+        description=description,
+        content=content,
+        date=date,
+        draft=draft,
+    )
+
+
+class TestTokenize:
+    def test_lowercases(self):
+        assert tokenize("Hello WORLD") == {"hello", "world"}
+
+    def test_splits_punctuation_and_hyphens(self):
+        assert tokenize("blue-tech: a post!") == {"blue", "tech", "a", "post"}
+
+    def test_keeps_digits(self):
+        assert tokenize("python 3.14") == {"python", "3", "14"}
+
+    def test_empty_string(self):
+        assert tokenize("") == set()
+
+    def test_punctuation_only(self):
+        assert tokenize("--- !!! ...") == set()
+
+
+class TestFieldWeighting:
+    def test_title_outranks_tags_outranks_description_outranks_body(self):
+        posts = [
+            _post("in-body", content="gumbo recipe steps"),
+            _post("in-title", title="Gumbo Night"),
+            _post("in-description", description="a gumbo story"),
+            _post("in-tags", tags=["gumbo"]),
+        ]
+        results = search_posts("gumbo", posts)
+        assert [r.url for r in results] == [
+            "/posts/in-title",
+            "/posts/in-tags",
+            "/posts/in-description",
+            "/posts/in-body",
+        ]
+
+    def test_exact_outranks_prefix_in_same_field(self):
+        posts = [
+            _post("prefix-hit", title="Gumbology Studies"),
+            _post("exact-hit", title="Gumbo Recipe"),
+        ]
+        results = search_posts("gumbo", posts)
+        assert [r.url for r in results] == ["/posts/exact-hit", "/posts/prefix-hit"]
+
+
+class TestPrefixMatching:
+    def test_prefix_matches(self):
+        posts = [_post("python-post", title="Python Tips")]
+        assert len(search_posts("pyth", posts)) == 1
+
+    def test_mid_word_substring_does_not_match(self):
+        posts = [_post("python-post", title="Python Tips")]
+        assert search_posts("ython", posts) == []
+
+
+class TestMultiTokenAnd:
+    def test_all_tokens_must_match(self):
+        posts = [_post("gumbo-post", title="Gumbo Recipe", content="cooking at midnight")]
+        assert len(search_posts("gumbo midnight", posts)) == 1
+        assert search_posts("gumbo zeppelin", posts) == []
+
+    def test_tokens_may_match_different_fields(self):
+        posts = [_post("mixed", title="Gumbo", tags=["cooking"])]
+        assert len(search_posts("gumbo cooking", posts)) == 1
+
+
+class TestRankingTieBreaks:
+    def test_equal_scores_order_by_date_desc_dateless_last(self):
+        posts = [
+            _post("old", title="Gumbo", date=datetime.date(2026, 1, 1)),
+            _post("dateless", title="Gumbo"),
+            _post("new", title="Gumbo", date=datetime.date(2026, 3, 1)),
+        ]
+        results = search_posts("gumbo", posts)
+        assert [r.url for r in results] == ["/posts/new", "/posts/old", "/posts/dateless"]
+
+
+class TestLimit:
+    def _many(self, n: int) -> list[Post]:
+        return [_post(f"post-{i}", title=f"Gumbo {i}", date=datetime.date(2026, 1, 1 + i)) for i in range(n)]
+
+    def test_default_limit(self):
+        assert len(search_posts("gumbo", self._many(12))) == DEFAULT_LIMIT
+
+    def test_explicit_limit(self):
+        assert len(search_posts("gumbo", self._many(12), limit=3)) == 3
+
+
+class TestDraftPassthrough:
+    def test_scorer_does_not_filter_drafts(self):
+        """Draft gating is the caller's job; the scorer returns drafts flagged."""
+        posts = [_post("secret", title="Gumbo Secrets", draft=True)]
+        results = search_posts("gumbo", posts)
+        assert len(results) == 1
+        assert results[0].draft is True
+
+
+class TestShortQueries:
+    def test_empty_query(self):
+        assert search_posts("", [_post("a", title="Gumbo")]) == []
+
+    def test_one_char_query(self):
+        assert search_posts("g", [_post("a", title="Gumbo")]) == []
+
+    def test_whitespace_query(self):
+        assert search_posts("   ", [_post("a", title="Gumbo")]) == []
+
+
+class TestResultShape:
+    def test_fields_carried_through(self):
+        post = _post(
+            "shaped",
+            title="Gumbo Guide",
+            tags=["cooking", "aliens"],
+            description="A short excerpt.",
+            content="body text",
+            date=datetime.date(2026, 2, 15),
+        )
+        result = search_posts("gumbo", [post])[0]
+        assert result.url == "/posts/shaped"
+        assert result.title == "Gumbo Guide"
+        assert result.tags == ["cooking", "aliens"]
+        assert result.excerpt == "A short excerpt."
+        assert result.date == datetime.date(2026, 2, 15)
+        assert result.draft is False
+
+    def test_search_index_matches_search_posts(self):
+        posts = [_post("a", title="Gumbo")]
+        index = build_search_index(posts)
+        assert search_index("gumbo", index) == search_posts("gumbo", posts)

--- a/themes/blue-tech/base.html
+++ b/themes/blue-tech/base.html
@@ -42,6 +42,8 @@
                 <a href="{{ page.url }}">{{ page.title }}</a>
                 {% endfor %}
             </div>
+            {% set search_mode = "input" %}
+            {% include "_search.html" %}
             <a href="/posts" class="nav-cta">Read Blog</a>
         </div>
     </nav>
@@ -58,5 +60,7 @@
             </p>
         </div>
     </footer>
+
+    <script src="/static/{{ theme_name }}/search.js" defer></script>
 </body>
 </html>

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -1003,3 +1003,124 @@ img {
         font-size: 0.9375rem;
     }
 }
+
+/* ============================================
+   Search (input mode — inline in the navbar)
+   ============================================ */
+.search {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-input {
+    width: 180px;
+    padding: 0.45rem 0.9rem;
+    font: inherit;
+    font-size: 0.875rem;
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.search-input::placeholder {
+    color: var(--color-text-dark);
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-accent);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.search-dropdown {
+    position: absolute;
+    top: calc(100% + 14px);
+    right: 0;
+    width: 340px;
+    max-width: calc(100vw - 2rem);
+    background: rgba(15, 23, 42, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--color-border-hover);
+    border-radius: var(--radius);
+    padding: 0.5rem;
+    z-index: 10;
+}
+
+.search-results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.search-result-link {
+    display: block;
+    padding: 0.55rem 0.7rem;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    color: var(--color-text);
+    transition: background var(--transition);
+}
+
+.search-result-link:hover,
+.search-results li.is-active .search-result-link {
+    background: rgba(59, 130, 246, 0.15);
+}
+
+.search-result-title {
+    display: block;
+    font-weight: 500;
+}
+
+.search-result-meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.78rem;
+    color: var(--color-text-subtle);
+}
+
+.search-result-draft {
+    background: rgba(59, 130, 246, 0.15);
+    border: 1px solid var(--color-accent);
+    color: var(--color-accent-light);
+    border-radius: 4px;
+    padding: 0 4px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+}
+
+.search-result-excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+}
+
+.search-empty {
+    margin: 0.5rem 0 0.25rem;
+    padding: 0 0.7rem;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+    .search-input {
+        width: 130px;
+    }
+}
+
+@media (max-width: 480px) {
+    .search-input {
+        width: 110px;
+        font-size: 0.8rem;
+    }
+}

--- a/themes/default/_search.html
+++ b/themes/default/_search.html
@@ -1,0 +1,29 @@
+{# Shared search component. Set search_mode before including:
+     {% set search_mode = "button" %}{% include "_search.html" %}
+   button: icon button opens a dropdown containing the input + results.
+   input:  input sits inline in the navbar; dropdown shows results only.
+   Behavior lives in /static/{theme_name}/search.js (default-theme fallback). #}
+{% set search_mode = search_mode | default("button") %}
+<div class="search" data-search="{{ search_mode }}">
+    {% if search_mode == "button" %}
+    <button type="button" class="search-toggle" aria-label="Search" aria-expanded="false">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+    </button>
+    {% else %}
+    <input class="search-input" type="search" placeholder="Search&hellip;" autocomplete="off"
+           role="combobox" aria-expanded="false" aria-controls="search-results" aria-autocomplete="list"
+           aria-label="Search posts">
+    {% endif %}
+    <div class="search-dropdown" hidden>
+        {% if search_mode == "button" %}
+        <input class="search-input" type="search" placeholder="Search&hellip;" autocomplete="off"
+               role="combobox" aria-expanded="false" aria-controls="search-results" aria-autocomplete="list"
+               aria-label="Search posts">
+        {% endif %}
+        <ul class="search-results" id="search-results" role="listbox" aria-label="Search results"></ul>
+        <p class="search-empty" hidden>No results</p>
+    </div>
+</div>

--- a/themes/default/base.html
+++ b/themes/default/base.html
@@ -53,6 +53,8 @@
                 {% for page in nav_pages %}
                 <a href="{{ page.url }}">{{ page.title }}</a>
                 {% endfor %}
+                {% set search_mode = "button" %}
+                {% include "_search.html" %}
                 <button class="theme-toggle" id="theme-toggle" aria-label="Switch to dark mode" aria-pressed="false">
                     <svg id="icon-sun" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
                         <circle cx="12" cy="12" r="5"></circle>
@@ -88,6 +90,7 @@
         </div>
     </footer>
 
+    <script src="/static/{{ theme_name }}/search.js" defer></script>
     <script>
     (function() {
         var toggle = document.getElementById('theme-toggle');

--- a/themes/default/static/search.js
+++ b/themes/default/static/search.js
@@ -67,10 +67,12 @@
             var opts = options();
             if (activeIndex >= 0 && opts[activeIndex]) {
                 opts[activeIndex].classList.remove('is-active');
+                opts[activeIndex].setAttribute('aria-selected', 'false');
             }
             activeIndex = index;
             if (index >= 0 && opts[index]) {
                 opts[index].classList.add('is-active');
+                opts[index].setAttribute('aria-selected', 'true');
                 input.setAttribute('aria-activedescendant', opts[index].id);
                 opts[index].scrollIntoView({ block: 'nearest' });
             } else {
@@ -87,6 +89,7 @@
             results.forEach(function (result, i) {
                 var item = document.createElement('li');
                 item.setAttribute('role', 'option');
+                item.setAttribute('aria-selected', 'false');
                 item.id = 'search-opt-' + i;
 
                 var link = document.createElement('a');

--- a/themes/default/static/search.js
+++ b/themes/default/static/search.js
@@ -1,0 +1,219 @@
+/* Navbar search: fetches /search?q= and renders a results dropdown.
+ *
+ * Works with the shared _search.html partial in both modes:
+ *   button — [data-search="button"]: a toggle button opens the dropdown
+ *            (which contains the input).
+ *   input  — [data-search="input"]: the input is inline in the navbar and
+ *            the dropdown shows results only.
+ *
+ * Results are rendered exclusively with createElement/textContent — never
+ * innerHTML — because titles/excerpts/tags are author-supplied content and
+ * Jinja autoescaping does not protect JSON-to-DOM rendering.
+ */
+(function () {
+    'use strict';
+
+    var DEBOUNCE_MS = 200;
+    var MIN_CHARS = 2;
+
+    function formatDate(iso) {
+        // Parse as local date parts; new Date("YYYY-MM-DD") is UTC and can
+        // shift a day in negative-offset timezones.
+        var parts = iso.split('-');
+        var d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
+        return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+    }
+
+    function initSearch(root) {
+        var mode = root.getAttribute('data-search') || 'button';
+        var toggle = root.querySelector('.search-toggle');
+        var input = root.querySelector('.search-input');
+        var dropdown = root.querySelector('.search-dropdown');
+        var list = root.querySelector('.search-results');
+        var empty = root.querySelector('.search-empty');
+        if (!input || !dropdown || !list) return;
+
+        var debounceTimer = null;
+        var controller = null;
+        var activeIndex = -1;
+
+        function setExpanded(expanded) {
+            input.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            if (toggle) toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        }
+
+        function openDropdown() {
+            dropdown.hidden = false;
+            setExpanded(true);
+        }
+
+        function closeDropdown() {
+            dropdown.hidden = true;
+            setExpanded(false);
+            setActive(-1);
+        }
+
+        function clearResults() {
+            list.textContent = '';
+            if (empty) empty.hidden = true;
+            setActive(-1);
+        }
+
+        function options() {
+            return list.querySelectorAll('[role="option"]');
+        }
+
+        function setActive(index) {
+            var opts = options();
+            if (activeIndex >= 0 && opts[activeIndex]) {
+                opts[activeIndex].classList.remove('is-active');
+            }
+            activeIndex = index;
+            if (index >= 0 && opts[index]) {
+                opts[index].classList.add('is-active');
+                input.setAttribute('aria-activedescendant', opts[index].id);
+                opts[index].scrollIntoView({ block: 'nearest' });
+            } else {
+                input.removeAttribute('aria-activedescendant');
+            }
+        }
+
+        function renderResults(results) {
+            clearResults();
+            if (results.length === 0) {
+                if (empty) empty.hidden = false;
+                return;
+            }
+            results.forEach(function (result, i) {
+                var item = document.createElement('li');
+                item.setAttribute('role', 'option');
+                item.id = 'search-opt-' + i;
+
+                var link = document.createElement('a');
+                link.className = 'search-result-link';
+                link.href = result.url;
+
+                var title = document.createElement('span');
+                title.className = 'search-result-title';
+                title.textContent = result.title;
+                link.appendChild(title);
+
+                var meta = document.createElement('span');
+                meta.className = 'search-result-meta';
+                if (result.date) {
+                    var date = document.createElement('span');
+                    date.className = 'search-result-date';
+                    date.textContent = formatDate(result.date);
+                    meta.appendChild(date);
+                }
+                if (result.draft) {
+                    var badge = document.createElement('span');
+                    badge.className = 'search-result-draft';
+                    badge.textContent = 'draft';
+                    meta.appendChild(badge);
+                }
+                if (meta.childNodes.length > 0) link.appendChild(meta);
+
+                if (result.excerpt) {
+                    var excerpt = document.createElement('span');
+                    excerpt.className = 'search-result-excerpt';
+                    excerpt.textContent = result.excerpt;
+                    link.appendChild(excerpt);
+                }
+
+                item.appendChild(link);
+                list.appendChild(item);
+            });
+        }
+
+        function runSearch(query) {
+            if (controller) controller.abort();
+            controller = new AbortController();
+            fetch('/search?q=' + encodeURIComponent(query), { signal: controller.signal })
+                .then(function (resp) { return resp.json(); })
+                .then(function (data) {
+                    // Guard against out-of-order responses: only render if
+                    // the input still shows the query this response answers.
+                    if (input.value.trim() !== data.query.trim()) return;
+                    renderResults(data.results);
+                    openDropdown();
+                })
+                .catch(function (err) {
+                    if (err.name !== 'AbortError') clearResults();
+                });
+        }
+
+        input.addEventListener('input', function () {
+            var query = input.value.trim();
+            if (debounceTimer) clearTimeout(debounceTimer);
+            if (query.length < MIN_CHARS) {
+                clearResults();
+                // Button mode keeps its panel open while focused; input
+                // mode hides the results-only dropdown.
+                if (mode === 'input') closeDropdown();
+                return;
+            }
+            debounceTimer = setTimeout(function () { runSearch(query); }, DEBOUNCE_MS);
+        });
+
+        input.addEventListener('focus', function () {
+            if (mode === 'input' && input.value.trim().length >= MIN_CHARS) {
+                openDropdown();
+            }
+        });
+
+        input.addEventListener('keydown', function (e) {
+            var opts = options();
+            if (e.key === 'ArrowDown' && opts.length > 0) {
+                e.preventDefault();
+                setActive(activeIndex < opts.length - 1 ? activeIndex + 1 : 0);
+            } else if (e.key === 'ArrowUp' && opts.length > 0) {
+                e.preventDefault();
+                setActive(activeIndex > 0 ? activeIndex - 1 : opts.length - 1);
+            } else if (e.key === 'Enter') {
+                var target = activeIndex >= 0 ? opts[activeIndex] : opts[0];
+                var link = target && target.querySelector('a');
+                if (link) {
+                    e.preventDefault();
+                    window.location.href = link.href;
+                }
+            }
+        });
+
+        if (toggle) {
+            toggle.addEventListener('click', function () {
+                if (dropdown.hidden) {
+                    openDropdown();
+                    input.focus();
+                } else {
+                    closeDropdown();
+                }
+            });
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+                e.preventDefault();
+                if (mode === 'button') openDropdown();
+                input.focus();
+            } else if (e.key === 'Escape' && !dropdown.hidden) {
+                closeDropdown();
+                input.blur();
+            }
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!root.contains(e.target)) closeDropdown();
+        });
+    }
+
+    function init() {
+        document.querySelectorAll('[data-search]').forEach(initSearch);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/themes/default/static/style.css
+++ b/themes/default/static/style.css
@@ -255,6 +255,137 @@ a:hover {
     display: block;
 }
 
+/* Search */
+.search {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-nav-toggle);
+    padding: 3px 6px;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.search-toggle:hover {
+    color: var(--color-nav-toggle-hover);
+}
+
+.search-toggle:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 3px;
+    border-radius: 2px;
+}
+
+.search-toggle svg {
+    display: block;
+}
+
+.search-dropdown {
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 0;
+    width: 320px;
+    max-width: calc(100vw - 2rem);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    padding: 0.5rem;
+    z-index: 200;
+}
+
+.search-input {
+    width: 100%;
+    padding: 0.45rem 0.6rem;
+    font: inherit;
+    font-size: 0.9rem;
+    color: var(--color-text);
+    background: var(--color-bg-subtle);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+}
+
+.search-input:focus {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+}
+
+.search-results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.search-results:not(:empty) {
+    margin-top: 0.5rem;
+}
+
+.search-dropdown .search-result-link {
+    display: block;
+    padding: 0.5rem 0.6rem;
+    border-radius: 6px;
+    text-decoration: none;
+    background: none;
+    color: var(--color-text);
+}
+
+.search-dropdown .search-result-link:hover,
+.search-dropdown li.is-active .search-result-link {
+    background: var(--color-accent-subtle-bg);
+}
+
+.search-result-title {
+    display: block;
+    font-weight: 500;
+    color: var(--color-link);
+}
+
+.search-result-meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+}
+
+.search-result-draft {
+    background: var(--color-accent-subtle-bg);
+    border: 1px solid var(--color-accent-subtle-border);
+    color: var(--color-accent);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+}
+
+.search-result-excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+}
+
+.search-empty {
+    margin: 0.5rem 0 0.25rem;
+    padding: 0 0.6rem;
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+}
+
 /* Main content */
 .main-content {
     flex: 1;

--- a/themes/terminal/base.html
+++ b/themes/terminal/base.html
@@ -54,6 +54,8 @@
                 {% for page in nav_pages %}
                 <a href="{{ page.url }}">{{ page.title }}</a>
                 {% endfor %}
+                {% set search_mode = "button" %}
+                {% include "_search.html" %}
             </div>
         </div>
     </nav>
@@ -73,6 +75,8 @@
     </footer>
 
     <script src="/static/{{ theme_name }}/js/pixel-font.js"></script>
+    {# search.js has no js/ prefix: it resolves via the default-theme static fallback #}
+    <script src="/static/{{ theme_name }}/search.js" defer></script>
     {% if theme.background in ['matrix', 'noise', 'hex'] %}
     <script src="/static/{{ theme_name }}/js/backgrounds.js"></script>
     {% endif %}

--- a/themes/terminal/static/css/style.css
+++ b/themes/terminal/static/css/style.css
@@ -125,7 +125,9 @@ img {
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    overflow: hidden;
+    /* No overflow: hidden here — it would clip the absolutely-positioned
+       search dropdown. The pixel-art logo is scaled down via transform and
+       stays within bounds on its own. */
 }
 
 .nav-logo {
@@ -1071,4 +1073,143 @@ img {
         padding: 12px 24px;
         font-size: 0.9375rem;
     }
+}
+
+/* Search (button mode — icon opens a dropdown panel) */
+.search {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.search-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-blue);
+    padding: 2px 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    transition: color 0.15s;
+}
+
+.search-toggle:hover {
+    color: var(--color-green);
+}
+
+.search-toggle svg {
+    display: block;
+}
+
+.search-dropdown {
+    position: absolute;
+    top: calc(100% + 16px);
+    right: 0;
+    width: 340px;
+    max-width: calc(100vw - 2rem);
+    background: var(--color-bg-card);
+    border: 1px solid rgba(59, 130, 246, 0.45);
+    border-radius: 4px;
+    padding: 0.6rem;
+    z-index: 10;
+    font-family: var(--font-mono);
+}
+
+.search-input {
+    width: 100%;
+    padding: 0.4rem 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(59, 130, 246, 0.45);
+    border-radius: 4px;
+}
+
+.search-input::placeholder {
+    color: var(--color-text-muted);
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: var(--color-blue);
+}
+
+.search-results {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.search-results:not(:empty) {
+    margin-top: 0.6rem;
+}
+
+.search-result-link {
+    display: block;
+    padding: 0.45rem 0.6rem;
+    text-decoration: none;
+    color: var(--color-text);
+}
+
+.search-result-link:hover,
+.search-results li.is-active .search-result-link {
+    background: rgba(74, 222, 128, 0.08);
+}
+
+.search-result-title {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-green);
+}
+
+.search-result-meta {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+}
+
+.search-result-draft {
+    border: 1px solid var(--color-blue);
+    color: var(--color-blue);
+    padding: 0 4px;
+    font-size: 0.65rem;
+    text-transform: lowercase;
+}
+
+.search-result-draft::before {
+    content: "[";
+}
+
+.search-result-draft::after {
+    content: "]";
+}
+
+.search-result-excerpt {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: 0.72rem;
+    color: var(--color-text-secondary);
+    margin-top: 2px;
+}
+
+.search-empty {
+    margin: 0.6rem 0 0.2rem;
+    padding: 0 0.6rem;
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+}
+
+.search-empty::before {
+    content: "// ";
+    color: var(--color-text-muted);
 }


### PR DESCRIPTION
Closes #11

## What

Keyword search for posts, accessible from the navbar on every page in all three bundled themes.

### Backend
- **`services/search.py`** — pure, unit-tested scorer: tokenize (lowercase `[a-z0-9]+`), exact + prefix match tiers, presence-based weights (title 12/8, tags 10/6, description 5/3, body 2/1), multi-token AND, score → date-desc tie-break.
- **`GET /search?q=`** — top 8 results as JSON `{query, results: [{title, url, date, tags, excerpt, draft}]}`. Queries under 2 chars return empty 200 (client fires per debounce tick). Registered before the pages catch-all.
- **Draft awareness without leakage** — anonymous visitors search published posts; admins also match drafts (flagged). The tokenized index is cached under two audience-separated keys (`search:index:published` / `search:index:all`, admin key only read behind `is_admin`); `/search` responses are never cached and carry `Cache-Control: no-store`. The webhook cache-warm pre-builds both variants.

### Frontend
- **Shared `_search.html` partial + `search.js`** (vanilla IIFE, no dependencies) reaching all themes via the default-theme template/static fallbacks; per-theme or per-site overridable.
- Two modes per the issue spec: **button** (icon opens dropdown w/ input — default, terminal) and **input** (inline navbar input — blue-tech). Shared behavior: 200ms debounce, results-as-you-type, `Cmd/Ctrl+K`, Escape, click-outside, arrow-key + Enter navigation with combobox/listbox ARIA, draft badge.
- **XSS-safe rendering**: results are built exclusively with `createElement`/`textContent` (frontmatter is author-supplied; autoescape doesn't cover JSON→DOM). Out-of-order responses guarded by AbortController + current-input check.
- Fixes terminal's `.nav-container` `overflow: hidden`, which clipped the dropdown (the sticky-nav risk called out in planning, confirmed and fixed during verification).

### Docs
- theme-creator skill: search component contract (`search_mode` + include, class hooks, override paths) and the `search.js` static-fallback note.

## Tests

28 new: 20 unit (`tests/test_search.py` — weighting, prefix vs substring, AND semantics, tie-breaks, limits, draft passthrough, result shape) + 8 integration (`tests/test_routes_search.py` — JSON shape/route reachability, draft hidden anon vs flagged admin, short/no-match queries, and **cache-separation in both request orders**). Full suite 323 passed; `run-checks.py` 4/4.

## Verified (dev server + Playwright, user-inspected in browser)

- All three themes: search flow, results rendering, navigation; terminal restyled per review (blue borders, slight rounding).
- Default: `Cmd+K`, light + dark dropdown, click-outside; fixed a `.nav-links a` style collision on result links.
- Blue-tech: inline input + frosted dropdown over the sticky nav, Escape close.
- Terminal: 375px mobile fit; pixel-art logo unaffected by the overflow fix.
- Drafts live-verified both ways (anonymous excluded; admin via `DEV_SKIP_AUTH` sees flagged result).

## Follow-up

Fuzzy matching (typo tolerance) deliberately out of scope — issue to be filed after merge (stdlib `difflib` tier, `rapidfuzz` upgrade path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)