### PR TITLE
fix(search): review follow-ups for body relevance, single-parse warm, scorer rename, and frontend scoping

### DIFF
--- a/src/squishmark/routers/search.py
+++ b/src/squishmark/routers/search.py
@@ -8,7 +8,7 @@ from squishmark.services.search import (
     DEFAULT_LIMIT,
     MIN_QUERY_LENGTH,
     get_search_index,
-    search_index,
+    query_index,
 )
 
 router = APIRouter(tags=["search"])
@@ -27,7 +27,7 @@ async def search(request: Request, q: str = Query("", max_length=200)) -> JSONRe
 
     if len(query) >= MIN_QUERY_LENGTH:
         index = await get_search_index(include_drafts=is_admin(request))
-        results = [r.model_dump(mode="json") for r in search_index(query, index, limit=DEFAULT_LIMIT)]
+        results = [r.model_dump(mode="json") for r in query_index(query, index, limit=DEFAULT_LIMIT)]
 
     return JSONResponse(
         content={"query": query, "results": results},

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -31,6 +31,18 @@ SEARCH_INDEX_ALL_KEY = "search:index:all"
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
 
+# Markdown noise stripped from post bodies before tokenization, so URLs,
+# HTML tags, and link targets don't pollute the index ("http"/"png" must
+# not match every post). Code-block *text* is deliberately kept searchable
+# — readers search for function names and commands that only appear in
+# code. Image regex runs before link regex ("![...](...)"" contains link
+# syntax); bare-URL regex runs last, after link targets are already gone.
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_MD_REF_DEF_RE = re.compile(r"^[ \t]*\[[^\]]+\]:\s+\S+.*$", re.MULTILINE)
+_HTML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
+_BARE_URL_RE = re.compile(r"(?:https?://|www\.)\S+")
+
 # Presence-based weights per (field, tier). Exact beats prefix within a
 # field; title beats tags beats description beats body across fields. No
 # term frequency — long bodies must not outrank a title hit.
@@ -49,6 +61,21 @@ def tokenize(text: str) -> set[str]:
     terms match their parts ("blue-tech" -> {"blue", "tech"}).
     """
     return set(_WORD_RE.findall(text.lower()))
+
+
+def strip_markdown_noise(text: str) -> str:
+    """Reduce markdown to its searchable text.
+
+    Keeps link text and image alt text but drops their URL targets,
+    reference-link definitions, HTML tags, and bare URLs. Markdown
+    punctuation (``#``, ``*``, backticks) needs no handling — the
+    tokenizer already splits it away.
+    """
+    text = _MD_IMAGE_RE.sub(r"\1", text)
+    text = _MD_LINK_RE.sub(r"\1", text)
+    text = _MD_REF_DEF_RE.sub(" ", text)
+    text = _HTML_TAG_RE.sub(" ", text)
+    return _BARE_URL_RE.sub(" ", text)
 
 
 class SearchResult(BaseModel):
@@ -90,7 +117,7 @@ def build_search_index(posts: list[Post]) -> list[IndexedPost]:
                 title_tokens=frozenset(tokenize(post.title)),
                 tag_tokens=frozenset(tokenize(" ".join(post.tags))),
                 description_tokens=frozenset(tokenize(post.description)),
-                body_tokens=frozenset(tokenize(post.content)),
+                body_tokens=frozenset(tokenize(strip_markdown_noise(post.content))),
             )
         )
     return index
@@ -124,7 +151,7 @@ def _score_post(query_tokens: list[str], indexed: IndexedPost) -> int:
     return total
 
 
-def search_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
+def query_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
     """Rank indexed posts against the query; top ``limit`` results.
 
     Every query token must match somewhere (exact or prefix) for a post to
@@ -149,15 +176,17 @@ def search_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMI
 
 def search_posts(query: str, posts: list[Post], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
     """Convenience: build an index and search it in one call."""
-    return search_index(query, build_search_index(posts), limit)
+    return query_index(query, build_search_index(posts), limit)
 
 
 async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     """Return the cached index for the audience, building it on miss.
 
     Building is the expensive part (get_all_posts re-parses every post's
-    markdown); the index inherits the cache's TTL and is invalidated by
-    the webhook's cache.clear() like every other derived blob.
+    markdown), so one miss parses everything once with drafts included and
+    caches both audience variants — the published index is just the drafts
+    filtered out. Both inherit the cache's TTL and are invalidated by the
+    webhook's cache.clear() like every other derived blob.
     """
     cache = get_cache()
     key = SEARCH_INDEX_ALL_KEY if include_drafts else SEARCH_INDEX_PUBLISHED_KEY
@@ -169,14 +198,18 @@ async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
     markdown_service = get_markdown_service(config)
-    posts = await get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
+    posts = await get_all_posts(github_service, markdown_service, include_drafts=True)
 
-    index = build_search_index(posts)
-    await cache.set(key, index)
-    return index
+    all_index = build_search_index(posts)
+    published_index = [indexed for indexed in all_index if not indexed.result.draft]
+    await cache.set(SEARCH_INDEX_ALL_KEY, all_index)
+    await cache.set(SEARCH_INDEX_PUBLISHED_KEY, published_index)
+    return all_index if include_drafts else published_index
 
 
 async def warm_search_indexes() -> None:
-    """Pre-build both audience index variants (used by the webhook warm)."""
-    await get_search_index(include_drafts=False)
+    """Pre-build both audience index variants (used by the webhook warm).
+
+    One call suffices: an index miss builds and caches both variants.
+    """
     await get_search_index(include_drafts=True)

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -35,7 +35,7 @@ _WORD_RE = re.compile(r"[a-z0-9]+")
 # HTML tags, and link targets don't pollute the index ("http"/"png" must
 # not match every post). Code-block *text* is deliberately kept searchable
 # — readers search for function names and commands that only appear in
-# code. Image regex runs before link regex ("![...](...)"" contains link
+# code. Image regex runs before link regex ("![...](...)" contains link
 # syntax); bare-URL regex runs last, after link targets are already gone.
 _MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^)]*\)")
 _MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,8 +10,9 @@ from squishmark.models.content import Post
 from squishmark.services.search import (
     DEFAULT_LIMIT,
     build_search_index,
-    search_index,
+    query_index,
     search_posts,
+    strip_markdown_noise,
     tokenize,
 )
 
@@ -160,7 +161,51 @@ class TestResultShape:
         assert result.date == datetime.date(2026, 2, 15)
         assert result.draft is False
 
-    def test_search_index_matches_search_posts(self):
+    def test_query_index_matches_search_posts(self):
         posts = [_post("a", title="Gumbo")]
         index = build_search_index(posts)
-        assert search_index("gumbo", index) == search_posts("gumbo", posts)
+        assert query_index("gumbo", index) == search_posts("gumbo", posts)
+
+
+class TestBodyMarkdownStripping:
+    def test_link_url_not_indexed_but_link_text_is(self):
+        posts = [_post("linked", content="Read [the gumbo guide](https://example.com/gumbo-guide.html) today")]
+        assert len(search_posts("guide", posts)) == 1
+        assert search_posts("example", posts) == []
+        assert search_posts("https", posts) == []
+
+    def test_image_url_not_indexed_but_alt_text_is(self):
+        posts = [_post("pic", content="![gumbo pot photo](/static/images/pot-final.png)")]
+        assert len(search_posts("photo", posts)) == 1
+        assert search_posts("png", posts) == []
+        assert search_posts("static", posts) == []
+
+    def test_bare_url_not_indexed(self):
+        posts = [_post("bare", content="See https://gumbo-archive.example.org/recipes for more")]
+        assert search_posts("archive", posts) == []
+        assert search_posts("recipes", posts) == []
+
+    def test_reference_link_definition_not_indexed(self):
+        posts = [_post("ref", content="Try the stew[1]\n\n[1]: https://example.com/stew-details\n")]
+        assert search_posts("details", posts) == []
+        assert len(search_posts("stew", posts)) == 1
+
+    def test_html_tags_not_indexed_but_their_text_is(self):
+        posts = [_post("html", content='<div class="callout">gumbo tips inside</div>')]
+        assert len(search_posts("tips", posts)) == 1
+        assert search_posts("callout", posts) == []
+        assert search_posts("div", posts) == []
+
+    def test_code_block_text_stays_searchable(self):
+        posts = [_post("code", content="```python\ndef make_roux(flour):\n    return flour\n```")]
+        assert len(search_posts("roux", posts)) == 1
+        assert len(search_posts("flour", posts)) == 1
+
+    def test_strip_preserves_plain_prose(self):
+        assert strip_markdown_noise("plain gumbo prose") == "plain gumbo prose"
+
+    def test_title_and_description_not_stripped(self):
+        """Stripping applies to the body only; other fields index as-is."""
+        posts = [_post("t", title="The https survival guide", description="all about png files")]
+        assert len(search_posts("https", posts)) == 1
+        assert len(search_posts("png", posts)) == 1

--- a/themes/default/_search.html
+++ b/themes/default/_search.html
@@ -2,7 +2,9 @@
      {% set search_mode = "button" %}{% include "_search.html" %}
    button: icon button opens a dropdown containing the input + results.
    input:  input sits inline in the navbar; dropdown shows results only.
-   Behavior lives in /static/{theme_name}/search.js (default-theme fallback). #}
+   Behavior lives in /static/{theme_name}/search.js (default-theme fallback).
+   Element ids and aria-controls are assigned per instance by search.js, so
+   a page may safely contain more than one search component. #}
 {% set search_mode = search_mode | default("button") %}
 <div class="search" data-search="{{ search_mode }}">
     {% if search_mode == "button" %}
@@ -14,16 +16,16 @@
     </button>
     {% else %}
     <input class="search-input" type="search" placeholder="Search&hellip;" autocomplete="off"
-           role="combobox" aria-expanded="false" aria-controls="search-results" aria-autocomplete="list"
+           role="combobox" aria-expanded="false" aria-autocomplete="list"
            aria-label="Search posts">
     {% endif %}
     <div class="search-dropdown" hidden>
         {% if search_mode == "button" %}
         <input class="search-input" type="search" placeholder="Search&hellip;" autocomplete="off"
-               role="combobox" aria-expanded="false" aria-controls="search-results" aria-autocomplete="list"
+               role="combobox" aria-expanded="false" aria-autocomplete="list"
                aria-label="Search posts">
         {% endif %}
-        <ul class="search-results" id="search-results" role="listbox" aria-label="Search results"></ul>
+        <ul class="search-results" role="listbox" aria-label="Search results"></ul>
         <p class="search-empty" hidden>No results</p>
     </div>
 </div>

--- a/themes/default/static/search.js
+++ b/themes/default/static/search.js
@@ -9,12 +9,20 @@
  * Results are rendered exclusively with createElement/textContent — never
  * innerHTML — because titles/excerpts/tags are author-supplied content and
  * Jinja autoescaping does not protect JSON-to-DOM rendering.
+ *
+ * Multiple instances per page are supported: element ids are scoped per
+ * instance and the document-level handlers (Cmd/Ctrl+K, Escape,
+ * click-outside) are registered once, over all instances. Cmd/Ctrl+K goes
+ * to the first instance (the navbar) and deliberately fires even when
+ * focus is in another text field — command-palette convention.
  */
 (function () {
     'use strict';
 
     var DEBOUNCE_MS = 200;
     var MIN_CHARS = 2;
+
+    var instances = [];
 
     function formatDate(iso) {
         // Parse as local date parts; new Date("YYYY-MM-DD") is UTC and can
@@ -24,7 +32,7 @@
         return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
     }
 
-    function initSearch(root) {
+    function initSearch(root, instanceIndex) {
         var mode = root.getAttribute('data-search') || 'button';
         var toggle = root.querySelector('.search-toggle');
         var input = root.querySelector('.search-input');
@@ -32,6 +40,10 @@
         var list = root.querySelector('.search-results');
         var empty = root.querySelector('.search-empty');
         if (!input || !dropdown || !list) return;
+
+        var listId = 'search-results-' + instanceIndex;
+        list.id = listId;
+        input.setAttribute('aria-controls', listId);
 
         var debounceTimer = null;
         var controller = null;
@@ -90,7 +102,7 @@
                 var item = document.createElement('li');
                 item.setAttribute('role', 'option');
                 item.setAttribute('aria-selected', 'false');
-                item.id = 'search-opt-' + i;
+                item.id = listId + '-opt-' + i;
 
                 var link = document.createElement('a');
                 link.className = 'search-result-link';
@@ -194,24 +206,41 @@
             });
         }
 
-        document.addEventListener('keydown', function (e) {
-            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-                e.preventDefault();
-                if (mode === 'button') openDropdown();
-                input.focus();
-            } else if (e.key === 'Escape' && !dropdown.hidden) {
-                closeDropdown();
-                input.blur();
-            }
-        });
-
-        document.addEventListener('click', function (e) {
-            if (!root.contains(e.target)) closeDropdown();
+        instances.push({
+            root: root,
+            mode: mode,
+            input: input,
+            dropdown: dropdown,
+            open: openDropdown,
+            close: closeDropdown
         });
     }
 
     function init() {
         document.querySelectorAll('[data-search]').forEach(initSearch);
+        if (instances.length === 0) return;
+
+        document.addEventListener('keydown', function (e) {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+                e.preventDefault();
+                var target = instances[0];
+                if (target.mode === 'button') target.open();
+                target.input.focus();
+            } else if (e.key === 'Escape') {
+                instances.forEach(function (inst) {
+                    if (!inst.dropdown.hidden) {
+                        inst.close();
+                        inst.input.blur();
+                    }
+                });
+            }
+        });
+
+        document.addEventListener('click', function (e) {
+            instances.forEach(function (inst) {
+                if (!inst.root.contains(e.target)) inst.close();
+            });
+        });
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
Closes #105

Follow-ups from the post-merge review of the search feature (#101). Four items, no behavior regressions.

## What

### Body index relevance
`build_search_index` now runs post bodies through `strip_markdown_noise()` before tokenizing: link/image URL targets (keeping link/alt text), reference-link definitions, HTML tags, and bare URLs are dropped. Queries like "http" or "png" no longer match nearly every post. **Code-block text stays searchable** by decision, since readers search for function names and commands.

Titles, tags, and descriptions index as-is (they're plain frontmatter, not markdown).

### Single-parse webhook warm
An index-cache miss now parses all posts **once** (drafts included) and caches both audience variants, deriving the published index by filtering drafts out of the all index. `warm_search_indexes()` is one call instead of two full parse loops. The draft-isolation property is unchanged: separate cache keys, admin key only read behind `is_admin`, `no-store` responses.

### Scorer rename
`search_index()` is now `query_index()`. The old name read as a noun and sat next to `get_search_index()` in the router imports.

### Frontend multi-instance robustness
- `_search.html` no longer hardcodes `id="search-results"`; `search.js` assigns instance-scoped ids and `aria-controls`/`aria-activedescendant` per component.
- The document-level `Cmd/Ctrl+K`, Escape, and click-outside handlers are registered **once** over an instance registry instead of once per search root. `Cmd/Ctrl+K` targets the first (navbar) instance and deliberately keeps firing even when focus is in another text field (command-palette convention, per decision).

This unblocks the #32 posts-page inline search reusing the component on the same page as the navbar search.

## Tests

8 new unit tests (`TestBodyMarkdownStripping`): link/image URL exclusion with text/alt retention, bare URLs, reference definitions, HTML tags, code-text retention, prose passthrough, and body-only scoping. Full suite 328 passed; `run-checks.py` 4/4.

## Verified

Dev server plus user-confirmed in browser: search flow, keyboard navigation, Escape/click-outside, `Cmd+K`, and the relevance change ("http"/"png" return nothing; code terms still hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)