### PR TITLE
chore(engine): log github fetch errors and tidy admin router

### DIFF
--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -2,6 +2,9 @@
 
 import json
 import logging
+import re
+import time
+from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -69,6 +72,15 @@ class CSRFTokenResponse(BaseModel):
 
 
 DbSession = Annotated[AsyncSession, Depends(get_db_session)]
+
+
+def _inject_dev_auth_banner(html: str) -> str:
+    """Insert the dev-mode auth-bypass banner after the opening <body> tag."""
+    templates_dir = Path(__file__).parent.parent / "templates"
+    banner_html = (templates_dir / "dev_auth_banner.html").read_text()
+    banner_css = (templates_dir / "dev_auth_banner.css").read_text()
+    banner = f"<style>{banner_css}</style>{banner_html}"
+    return re.sub(r"(<body[^>]*>)", r"\1" + banner, html, count=1)
 
 
 def _to_note_response(note: Note) -> NoteResponse:
@@ -208,14 +220,7 @@ async def admin_dashboard(
     # Inject dev mode banner if auth bypass is active
     settings = get_settings()
     if settings.debug and settings.dev_skip_auth:
-        import re
-        from pathlib import Path
-
-        templates_dir = Path(__file__).parent.parent / "templates"
-        banner_html = (templates_dir / "dev_auth_banner.html").read_text()
-        banner_css = (templates_dir / "dev_auth_banner.css").read_text()
-        banner = f"<style>{banner_css}</style>{banner_html}"
-        html = re.sub(r"(<body[^>]*>)", r"\1" + banner, html, count=1)
+        html = _inject_dev_auth_banner(html)
 
     return HTMLResponse(content=html)
 
@@ -369,8 +374,6 @@ async def refresh_cache(
     admin: AdminUser,
 ) -> CacheRefreshResponse:
     """Clear and refresh the content cache."""
-    import time
-
     start = time.time()
 
     # Clear the cache

--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -77,10 +77,11 @@ DbSession = Annotated[AsyncSession, Depends(get_db_session)]
 def _inject_dev_auth_banner(html: str) -> str:
     """Insert the dev-mode auth-bypass banner after the opening <body> tag."""
     templates_dir = Path(__file__).parent.parent / "templates"
-    banner_html = (templates_dir / "dev_auth_banner.html").read_text()
-    banner_css = (templates_dir / "dev_auth_banner.css").read_text()
+    banner_html = (templates_dir / "dev_auth_banner.html").read_text(encoding="utf-8")
+    banner_css = (templates_dir / "dev_auth_banner.css").read_text(encoding="utf-8")
     banner = f"<style>{banner_css}</style>{banner_html}"
-    return re.sub(r"(<body[^>]*>)", r"\1" + banner, html, count=1)
+    # Callable replacement so backslashes in the banner are inserted literally
+    return re.sub(r"(<body[^>]*>)", lambda m: m.group(1) + banner, html, count=1)
 
 
 def _to_note_response(note: Note) -> NoteResponse:

--- a/src/squishmark/services/github.py
+++ b/src/squishmark/services/github.py
@@ -1,6 +1,7 @@
 """GitHub content fetching service."""
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -9,6 +10,8 @@ import httpx
 
 from squishmark.config import Settings, parse_file_url
 from squishmark.services.cache import Cache, get_cache
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -77,6 +80,7 @@ class GitHubService:
 
             return GitHubFile(path=path, content=content)
         except Exception:
+            logger.warning("Failed to read local file %r", path, exc_info=True)
             return None
 
     async def _fetch_github_file(self, path: str, ref: str = "main") -> GitHubFile | None:
@@ -93,7 +97,8 @@ class GitHubService:
                 return None
             response.raise_for_status()
             return GitHubFile(path=path, content=response.text)
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            logger.warning("Failed to fetch %s from GitHub: %s", url, exc)
             return None
 
     async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
@@ -122,7 +127,7 @@ class GitHubService:
         else:
             result = await self._fetch_github_file(path, ref)
 
-        # Cache the result (even None to avoid repeated lookups)
+        # Cache only successful results; misses stay uncached so they can retry.
         if use_cache and result is not None:
             await self.cache.set(cache_key, result)
 
@@ -162,6 +167,7 @@ class GitHubService:
                 content_type=self._get_content_type(path),
             )
         except Exception:
+            logger.warning("Failed to read local binary file %r", path, exc_info=True)
             return None
 
     async def _fetch_github_binary_file(self, path: str, ref: str = "main") -> GitHubBinaryFile | None:
@@ -181,7 +187,8 @@ class GitHubService:
                 content=response.content,
                 content_type=self._get_content_type(path),
             )
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            logger.warning("Failed to fetch binary %s from GitHub: %s", url, exc)
             return None
 
     async def get_binary_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubBinaryFile | None:
@@ -233,6 +240,7 @@ class GitHubService:
 
             return await loop.run_in_executor(None, _list_files)
         except Exception:
+            logger.warning("Failed to list local directory %r", path, exc_info=True)
             return []
 
     async def _list_github_directory(self, path: str, ref: str = "main") -> list[str]:
@@ -254,7 +262,8 @@ class GitHubService:
                 return []
 
             return sorted([item["path"] for item in items if item["type"] == "file"])
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            logger.warning("Failed to list GitHub directory %s: %s", url, exc)
             return []
 
     async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
@@ -318,7 +327,8 @@ class GitHubService:
             if use_cache:
                 await self.cache.set(cache_key, config)
             return config
-        except yaml.YAMLError:
+        except yaml.YAMLError as exc:
+            logger.warning("Failed to parse config YAML: %s", exc)
             return None
 
 


### PR DESCRIPTION
Closes #113

- Log warning on all previously silent error paths in the GitHub content service (local reads, HTTP fetches, directory listings, config YAML parse); expected 404s stay quiet, return behavior unchanged
- Fix stale comment in `get_file`: only non-None results are cached
- Hoist inline `re`, `time`, and `Path` imports in the admin router to module level
- Extract dev-banner HTML injection into a module-level `_inject_dev_auth_banner` helper

Checks: format, lint, pytest (328), pyright all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)