### PR TITLE
fix(theme): make template lookup stateless with theme-prefixed names

### DIFF
--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -3,13 +3,13 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from jinja2 import Environment, TemplateNotFound
+from jinja2 import TemplateNotFound
 
 from squishmark.models.content import Config, Page, Pagination, Post
 from squishmark.services.markdown import get_markdown_service
 from squishmark.services.theme.favicon import FaviconDetector
 from squishmark.services.theme.filters import register_filters
-from squishmark.services.theme.loader import AsyncHybridLoader
+from squishmark.services.theme.loader import AsyncHybridLoader, ThemedEnvironment
 
 if TYPE_CHECKING:
     from squishmark.services.github import GitHubService
@@ -44,12 +44,12 @@ class ThemeEngine:
 
         # Create loader and environment
         self.loader = AsyncHybridLoader(themes_path)
-        self.env = Environment(
+        self.env = ThemedEnvironment(
             loader=self.loader,
             autoescape=True,
             trim_blocks=True,
             lstrip_blocks=True,
-            auto_reload=True,  # Always check uptodate() to support dynamic theme switching
+            auto_reload=True,  # Always check uptodate() to support live theme editing
         )
 
         # Add custom filters
@@ -153,10 +153,9 @@ class ThemeEngine:
         # Resolve theme name (override or config default)
         theme_name = theme_override or config.theme.name
 
-        # Set the loader's current theme before getting template
-        self.loader.current_theme = theme_name
-
-        template = self.env.get_template(template_name)
+        # Theme-prefixed name so lookup is stateless (loader resolves the
+        # custom / theme / default fallback chain from the prefix).
+        template = self.env.get_template(f"{theme_name}/{template_name}")
 
         # Detect favicon if not explicitly set in config
         favicon_url = config.site.favicon
@@ -303,18 +302,10 @@ class ThemeEngine:
         For HTMX swaps where we only need a self-contained snippet (no nav,
         no favicon, no GitHub fetches). The partial must not depend on
         site/theme/canonical context.
-
-        The previous ``current_theme`` is restored after rendering so concurrent
-        requests don't see each other's theme leak through this shared loader.
         """
-        previous_theme = self.loader.current_theme
-        try:
-            if theme_override:
-                self.loader.current_theme = theme_override
-            template = self.env.get_template(template_name)
-            return template.render(**context)
-        finally:
-            self.loader.current_theme = previous_theme
+        theme_name = theme_override or self.loader.default_theme
+        template = self.env.get_template(f"{theme_name}/{template_name}")
+        return template.render(**context)
 
 
 # Global theme engine instance

--- a/src/squishmark/services/theme/loader.py
+++ b/src/squishmark/services/theme/loader.py
@@ -6,32 +6,52 @@ from typing import Any
 from jinja2 import BaseLoader, Environment, TemplateNotFound
 
 
+def split_theme(name: str, default_theme: str) -> tuple[str, str]:
+    """Split a theme-prefixed template name into ``(theme, template)``.
+
+    Names are of the form ``"<theme>/<template>"`` (e.g. ``"terminal/post.html"``
+    or ``"terminal/admin/admin.html"``). A name without a slash carries no theme
+    prefix and resolves against the default theme.
+    """
+    theme, sep, rest = name.partition("/")
+    if not sep:
+        return default_theme, name
+    return theme, rest
+
+
+class ThemedEnvironment(Environment):
+    """Jinja environment that keeps extends/includes within the parent's theme.
+
+    Template names are theme-prefixed (``"<theme>/<name>"``). When a template
+    references another by bare name, the reference is resolved against the
+    parent's theme so inheritance stays within the requested theme. Fallback to
+    the default theme is handled by :class:`AsyncHybridLoader`.
+    """
+
+    def join_path(self, template: str, parent: str) -> str:
+        theme, sep, _rest = parent.partition("/")
+        if not sep:
+            return template
+        return f"{theme}/{template}"
+
+
 class AsyncHybridLoader(BaseLoader):
     """
     Async-friendly template loader that caches templates in memory.
     Templates must be pre-loaded before rendering.
 
-    Supports loading from:
-    1. Custom templates cache (from content repo)
-    2. Current bundled theme directory
+    Lookup is stateless: the requested theme is encoded in the template name
+    (``"<theme>/<name>"``). For each lookup the sources are searched in order:
+
+    1. Custom templates cache (from content repo), keyed by bare name
+    2. Requested theme directory
     3. Default bundled theme directory (fallback)
     """
 
     def __init__(self, themes_path: Path, default_theme: str = "default") -> None:
         self.themes_path = themes_path
         self.default_theme = default_theme
-        self._current_theme: str = default_theme
         self._template_cache: dict[str, str] = {}
-
-    @property
-    def current_theme(self) -> str:
-        """Get the current theme name."""
-        return self._current_theme
-
-    @current_theme.setter
-    def current_theme(self, value: str) -> None:
-        """Set the current theme name."""
-        self._current_theme = value
 
     def add_template(self, name: str, source: str) -> None:
         """Add a template to the cache."""
@@ -42,22 +62,25 @@ class AsyncHybridLoader(BaseLoader):
         self._template_cache.clear()
 
     def get_source(self, environment: Environment, template: str) -> tuple[str, str | None, Any]:
-        """Load a template from cache, current theme, or default theme."""
-        # Check cache first (custom templates from content repo)
-        if template in self._template_cache:
-            return self._template_cache[template], template, lambda: True
+        """Load a template from cache, requested theme, or default theme."""
+        theme, name = split_theme(template, self.default_theme)
 
-        # Try current theme directory
-        if self._current_theme != self.default_theme:
-            current_path = self.themes_path / self._current_theme / template
-            if current_path.exists():
-                # Return lambda: False to force reload when theme changes
-                return current_path.read_text(encoding="utf-8"), str(current_path), lambda: False
+        # Custom templates from the content repo take precedence, keyed by their
+        # bare name as loaded (see ThemeEngine.load_custom_templates).
+        if name in self._template_cache:
+            return self._template_cache[name], template, lambda: True
 
-        # Fall back to default theme
-        default_path = self.themes_path / self.default_theme / template
+        # Requested theme directory (skipped when it is the default theme).
+        # Return the prefixed name so join_path can recover the theme, and
+        # lambda: False to always re-read (supports live theme editing).
+        if theme != self.default_theme:
+            theme_path = self.themes_path / theme / name
+            if theme_path.exists():
+                return theme_path.read_text(encoding="utf-8"), template, lambda: False
+
+        # Fall back to the default theme.
+        default_path = self.themes_path / self.default_theme / name
         if default_path.exists():
-            # Return lambda: False to force reload when theme changes
-            return default_path.read_text(encoding="utf-8"), str(default_path), lambda: False
+            return default_path.read_text(encoding="utf-8"), template, lambda: False
 
         raise TemplateNotFound(template)

--- a/src/squishmark/services/theme/loader.py
+++ b/src/squishmark/services/theme/loader.py
@@ -19,6 +19,11 @@ def split_theme(name: str, default_theme: str) -> tuple[str, str]:
     return theme, rest
 
 
+def _is_unsafe(part: str) -> bool:
+    """True when a theme or template name could escape themes_path."""
+    return not part or part.startswith("/") or "\\" in part or ".." in part.split("/")
+
+
 class ThemedEnvironment(Environment):
     """Jinja environment that keeps extends/includes within the parent's theme.
 
@@ -64,6 +69,10 @@ class AsyncHybridLoader(BaseLoader):
     def get_source(self, environment: Environment, template: str) -> tuple[str, str | None, Any]:
         """Load a template from cache, requested theme, or default theme."""
         theme, name = split_theme(template, self.default_theme)
+
+        # Reject names that could traverse outside themes_path.
+        if _is_unsafe(theme) or _is_unsafe(name):
+            raise TemplateNotFound(template)
 
         # Custom templates from the content repo take precedence, keyed by their
         # bare name as loaded (see ThemeEngine.load_custom_templates).

--- a/tests/test_admin_notes.py
+++ b/tests/test_admin_notes.py
@@ -474,41 +474,38 @@ async def test_update_note_htmx_form_missing_text_leaves_text_unchanged():
     mock_service.update_note.assert_called_once_with(note_id=1, text=None, is_public=True)
 
 
-@pytest.mark.asyncio
-async def test_render_partial_restores_current_theme():
-    """ThemeEngine.render_partial must restore the previous current_theme after rendering."""
+def test_render_partial_uses_theme_prefixed_name():
+    """render_partial must look up the theme-prefixed template name."""
     from unittest.mock import MagicMock as MM
 
     from squishmark.services.theme.engine import ThemeEngine
 
     engine = ThemeEngine.__new__(ThemeEngine)
     engine.loader = MM()
-    engine.loader.current_theme = "blue-tech"
+    engine.loader.default_theme = "default"
     engine.env = MM()
     engine.env.get_template.return_value.render.return_value = "<div></div>"
 
     engine.render_partial("admin/_note_item.html", theme_override="terminal")
 
-    assert engine.loader.current_theme == "blue-tech"
+    engine.env.get_template.assert_called_once_with("terminal/admin/_note_item.html")
 
 
-@pytest.mark.asyncio
-async def test_render_partial_restores_theme_on_render_exception():
-    """The previous current_theme must be restored even if rendering raises."""
+def test_render_partial_defaults_to_default_theme():
+    """Without an override, render_partial resolves against the default theme."""
     from unittest.mock import MagicMock as MM
 
     from squishmark.services.theme.engine import ThemeEngine
 
     engine = ThemeEngine.__new__(ThemeEngine)
     engine.loader = MM()
-    engine.loader.current_theme = "default"
+    engine.loader.default_theme = "default"
     engine.env = MM()
-    engine.env.get_template.return_value.render.side_effect = RuntimeError("template crash")
+    engine.env.get_template.return_value.render.return_value = "<div></div>"
 
-    with pytest.raises(RuntimeError, match="template crash"):
-        engine.render_partial("admin/_note_item.html", theme_override="terminal")
+    engine.render_partial("admin/_note_item.html")
 
-    assert engine.loader.current_theme == "default"
+    engine.env.get_template.assert_called_once_with("default/admin/_note_item.html")
 
 
 @pytest.mark.asyncio

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -88,6 +88,42 @@ class TestLoaderFallbackChain:
         assert name == "terminal/base.html"
 
 
+class TestTraversalRejection:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "terminal/../secrets.txt",
+            "terminal/../../etc/hosts",
+            "../default/base.html",
+            "/etc/hosts",
+            "terminal//etc/hosts",
+            "terminal/..\\..\\etc\\hosts",
+            "..\\etc\\hosts",
+        ],
+    )
+    def test_traversal_names_rejected(self, tmp_path: Path, name: str):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        with pytest.raises(TemplateNotFound):
+            loader.get_source(MagicMock(), name)
+
+    def test_include_traversal_rejected(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        (tmp_path / "terminal" / "evil.html").write_text('{% include "../../secret.txt" %}', encoding="utf-8")
+        (tmp_path / "secret.txt").write_text("SECRET", encoding="utf-8")
+        env = ThemedEnvironment(loader=AsyncHybridLoader(tmp_path))
+        with pytest.raises(TemplateNotFound):
+            env.get_template("terminal/evil.html").render()
+
+    def test_nested_names_still_resolve(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        admin_dir = tmp_path / "terminal" / "admin"
+        admin_dir.mkdir()
+        (admin_dir / "admin.html").write_text("ADMIN:terminal", encoding="utf-8")
+        env = ThemedEnvironment(loader=AsyncHybridLoader(tmp_path))
+        assert env.get_template("terminal/admin/admin.html").render() == "ADMIN:terminal"
+
+
 class TestThemedEnvironmentJoinPath:
     def test_keeps_reference_within_parent_theme(self, tmp_path: Path):
         _build_themes(tmp_path)

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -1,0 +1,146 @@
+"""Tests for the stateless theme-prefixed template loader (issue #110)."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from jinja2 import TemplateNotFound
+
+from squishmark.models.content import Config
+from squishmark.services.theme.engine import ThemeEngine
+from squishmark.services.theme.loader import (
+    AsyncHybridLoader,
+    ThemedEnvironment,
+    split_theme,
+)
+
+
+def _build_themes(root: Path) -> None:
+    """Create a minimal three-theme tree for lookup tests.
+
+    Only ``default`` ships ``shared.html``; ``blue-tech`` and ``terminal`` rely
+    on the default-theme fallback for it.
+    """
+    for theme in ("default", "blue-tech", "terminal"):
+        theme_dir = root / theme
+        theme_dir.mkdir(parents=True)
+        (theme_dir / "base.html").write_text(f"BASE:{theme}", encoding="utf-8")
+        # A child that extends its own theme's base by bare name.
+        (theme_dir / "child.html").write_text('{% extends "base.html" %}', encoding="utf-8")
+    # shared.html only exists in the default theme.
+    (root / "default" / "shared.html").write_text("SHARED:default", encoding="utf-8")
+
+
+class TestSplitTheme:
+    def test_prefixed_name(self):
+        assert split_theme("terminal/post.html", "default") == ("terminal", "post.html")
+
+    def test_nested_name_keeps_remainder(self):
+        assert split_theme("terminal/admin/admin.html", "default") == (
+            "terminal",
+            "admin/admin.html",
+        )
+
+    def test_bare_name_uses_default_theme(self):
+        assert split_theme("post.html", "default") == ("default", "post.html")
+
+
+class TestLoaderFallbackChain:
+    def test_requested_theme_wins(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        source, _name, _uptodate = loader.get_source(MagicMock(), "terminal/base.html")
+        assert source == "BASE:terminal"
+
+    def test_falls_back_to_default_theme(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        # terminal has no shared.html, so the default theme provides it.
+        source, _name, _uptodate = loader.get_source(MagicMock(), "terminal/shared.html")
+        assert source == "SHARED:default"
+
+    def test_custom_cache_beats_theme_and_default(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        loader.add_template("base.html", "CUSTOM:base")
+        source, _name, _uptodate = loader.get_source(MagicMock(), "terminal/base.html")
+        assert source == "CUSTOM:base"
+
+    def test_default_theme_request_skips_theme_lookup(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        source, _name, _uptodate = loader.get_source(MagicMock(), "default/base.html")
+        assert source == "BASE:default"
+
+    def test_missing_template_raises(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        with pytest.raises(TemplateNotFound):
+            loader.get_source(MagicMock(), "terminal/does-not-exist.html")
+
+    def test_returned_name_is_theme_prefixed(self, tmp_path: Path):
+        """The filename passed back must stay theme-prefixed so join_path can
+        recover the theme for extends/includes."""
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        _source, name, _uptodate = loader.get_source(MagicMock(), "terminal/base.html")
+        assert name == "terminal/base.html"
+
+
+class TestThemedEnvironmentJoinPath:
+    def test_keeps_reference_within_parent_theme(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        env = ThemedEnvironment(loader=AsyncHybridLoader(tmp_path))
+        # child.html extends "base.html"; it must resolve within its own theme.
+        assert env.get_template("terminal/child.html").render() == "BASE:terminal"
+        assert env.get_template("blue-tech/child.html").render() == "BASE:blue-tech"
+        assert env.get_template("default/child.html").render() == "BASE:default"
+
+    def test_bare_parent_returns_reference_unchanged(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        env = ThemedEnvironment(loader=AsyncHybridLoader(tmp_path))
+        assert env.join_path("base.html", "child.html") == "base.html"
+
+
+def _make_engine(themes_path: Path) -> ThemeEngine:
+    github_service = MagicMock()
+    github_service.list_directory = AsyncMock(return_value=[])
+    engine = ThemeEngine(github_service, themes_path=themes_path)
+
+    # Favicon detection is an await point in render(); yield control there so
+    # concurrent renders interleave (this is where the old shared state raced).
+    async def _detect() -> None:
+        await asyncio.sleep(0)
+        return None
+
+    engine.favicon_detector.detect = _detect  # type: ignore[assignment]
+    return engine
+
+
+class TestConcurrentRenders:
+    @pytest.mark.asyncio
+    async def test_concurrent_theme_overrides_do_not_cross_contaminate(self, tmp_path: Path):
+        """Renders with different theme overrides must resolve extends within
+        their own theme even when interleaved (issue #110)."""
+        _build_themes(tmp_path)
+        # index.html extends base.html by bare name, exercising the loader.
+        for theme in ("blue-tech", "terminal", "default"):
+            (tmp_path / theme / "index.html").write_text('{% extends "base.html" %}', encoding="utf-8")
+        engine = _make_engine(tmp_path)
+        config = Config()
+
+        results = await asyncio.gather(
+            *[
+                engine.render("index.html", config, theme_override=theme)
+                for theme in ("blue-tech", "terminal", "default", "terminal", "blue-tech")
+            ]
+        )
+
+        assert results == [
+            "BASE:blue-tech",
+            "BASE:terminal",
+            "BASE:default",
+            "BASE:terminal",
+            "BASE:blue-tech",
+        ]


### PR DESCRIPTION
Closes #110

The loader's mutable `current_theme` allowed concurrent requests with different theme overrides to cross-contaminate template resolution, since Jinja resolves extends/includes through the loader at render time.

- Template names now carry a theme prefix (`<theme>/<template>`); the loader resolves the same custom cache, theme dir, default dir fallback chain per lookup with no shared state
- New `ThemedEnvironment.join_path` keeps extends/includes within the parent template's theme
- Removed `loader.current_theme` and the save/restore logic in `render_partial`
- New `tests/test_theme_loader.py`: fallback chain, join_path, and a concurrent-render test interleaving all three themes

Verification: checks green (340 tests). Browser-verified all three bundled themes (default, blue-tech, terminal) on index and post pages, a per-post `theme: blue-tech` override rendering alongside a default-theme index, and 30 concurrent mixed-theme requests with zero CSS cross-contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)