### PR TITLE
perf(content): cache parsed posts and pages across requests

### DIFF
--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -15,9 +15,11 @@ from squishmark.models.content import Config
 from squishmark.models.db import Note, get_db_session
 from squishmark.services.analytics import AnalyticsService
 from squishmark.services.cache import get_cache
+from squishmark.services.content import warm_content_caches
 from squishmark.services.csrf import get_or_create_csrf_token, verify_csrf_token
 from squishmark.services.github import get_github_service
 from squishmark.services.notes import NotesService
+from squishmark.services.search import warm_search_indexes
 from squishmark.services.theme import get_theme_engine, reset_theme_engine
 
 logger = logging.getLogger(__name__)
@@ -398,6 +400,10 @@ async def refresh_cache(
 
     # Reload theme engine
     await get_theme_engine(github_service)
+
+    # Pre-parse posts, pages, and search indexes so the next request isn't cold
+    await warm_content_caches()
+    await warm_search_indexes()
 
     duration_ms = (time.time() - start) * 1000
     warmed = cache.size

--- a/src/squishmark/routers/feed.py
+++ b/src/squishmark/routers/feed.py
@@ -8,9 +8,8 @@ from fastapi.responses import Response
 
 from squishmark.models.content import Config, Post
 from squishmark.services.cache import get_cache
-from squishmark.services.content import get_all_posts
+from squishmark.services.content import get_cached_posts
 from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
 
 router = APIRouter(tags=["feed"])
 
@@ -90,9 +89,8 @@ async def atom_feed() -> Response:
     github_service = get_github_service()
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
-    markdown_service = get_markdown_service(config)
 
-    posts = await get_all_posts(github_service, markdown_service)
+    posts = await get_cached_posts(include_drafts=False)
     posts = posts[:20]  # Limit to 20 most recent
 
     xml_bytes = _build_atom_feed(config, posts)

--- a/src/squishmark/routers/pages.py
+++ b/src/squishmark/routers/pages.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from squishmark.dependencies import is_admin
 from squishmark.models.content import Config
 from squishmark.models.db import get_db_session
-from squishmark.services.content import get_all_posts, get_featured_posts
+from squishmark.services.content import get_cached_posts, get_featured_posts
 from squishmark.services.github import get_github_service
 from squishmark.services.markdown import get_markdown_service
 from squishmark.services.notes import NotesService
@@ -56,8 +56,8 @@ async def get_page(
     notes_service = NotesService(db)
     notes = await notes_service.get_for_path(f"/{slug}", include_private=admin)
 
-    # Featured posts for template context
-    all_posts = await get_all_posts(github_service, markdown_service)
+    # Featured posts for template context (published only, shown to everyone)
+    all_posts = await get_cached_posts(include_drafts=False)
     featured = get_featured_posts(all_posts, config.site)
 
     # Render

--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -7,9 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from squishmark.dependencies import is_admin
 from squishmark.models.content import Config, Pagination
 from squishmark.models.db import get_db_session
-from squishmark.services.content import build_series_context, get_all_posts, get_featured_posts
+from squishmark.services.content import build_series_context, get_cached_posts, get_featured_posts
 from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
 from squishmark.services.notes import NotesService
 from squishmark.services.theme import get_theme_engine
 
@@ -28,12 +27,9 @@ async def list_posts(
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
 
-    # Get markdown service with config
-    markdown_service = get_markdown_service(config)
-
     # Get all posts (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
+    all_posts = await get_cached_posts(include_drafts=include_drafts)
 
     # Paginate
     per_page = config.posts.per_page
@@ -77,12 +73,9 @@ async def get_post(
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
 
-    # Get markdown service with config
-    markdown_service = get_markdown_service(config)
-
     # Get all posts and find the matching one (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_all_posts(github_service, markdown_service, include_drafts=include_drafts)
+    all_posts = await get_cached_posts(include_drafts=include_drafts)
 
     post = next((p for p in all_posts if p.slug == slug), None)
 

--- a/src/squishmark/routers/seo.py
+++ b/src/squishmark/routers/seo.py
@@ -8,9 +8,8 @@ from fastapi.responses import Response
 
 from squishmark.models.content import Config, Page, Post
 from squishmark.services.cache import get_cache
-from squishmark.services.content import get_all_pages, get_all_posts
+from squishmark.services.content import get_cached_pages, get_cached_posts
 from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
 
 router = APIRouter(tags=["seo"])
 
@@ -80,10 +79,9 @@ async def sitemap_xml() -> Response:
     github_service = get_github_service()
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
-    markdown_service = get_markdown_service(config)
 
-    posts = await get_all_posts(github_service, markdown_service)
-    pages = await get_all_pages(github_service, markdown_service)
+    posts = await get_cached_posts(include_drafts=False)
+    pages = await get_cached_pages(include_hidden=False)
 
     xml_bytes = _build_sitemap(config, posts, pages)
     await cache.set(SITEMAP_CACHE_KEY, xml_bytes)

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from squishmark.config import get_settings
 from squishmark.services.cache import get_cache
+from squishmark.services.content import warm_content_caches
 from squishmark.services.github import get_github_service
 from squishmark.services.search import warm_search_indexes
 from squishmark.services.theme import get_theme_engine, reset_theme_engine
@@ -90,6 +91,9 @@ async def github_webhook(request: Request) -> dict:
 
     # Reload theme engine
     await get_theme_engine(github_service)
+
+    # Pre-parse posts and pages so the first render after a push isn't cold
+    await warm_content_caches()
 
     # Pre-build both search index variants so the first search isn't cold
     await warm_search_indexes()

--- a/src/squishmark/services/content.py
+++ b/src/squishmark/services/content.py
@@ -3,9 +3,18 @@
 import datetime
 from typing import Any
 
-from squishmark.models.content import Page, Post, SiteConfig
-from squishmark.services.github import GitHubService
-from squishmark.services.markdown import MarkdownService
+from squishmark.models.content import Config, Page, Post, SiteConfig
+from squishmark.services.cache import get_cache
+from squishmark.services.github import GitHubService, get_github_service
+from squishmark.services.markdown import MarkdownService, get_markdown_service
+
+# Audience-separated cache keys. The "all" variants include drafts (posts) and
+# hidden pages, so they must only ever be served to admins: sharing a key would
+# leak unpublished content to anonymous visitors. Mirrors the search index keys.
+POSTS_ALL_KEY = "content:posts:all"
+POSTS_PUBLISHED_KEY = "content:posts:published"
+PAGES_ALL_KEY = "content:pages:all"
+PAGES_VISIBLE_KEY = "content:pages:visible"
 
 
 async def get_all_posts(
@@ -130,3 +139,67 @@ async def get_all_pages(
         pages.append(page)
 
     return pages
+
+
+async def _build_content_services() -> tuple[GitHubService, MarkdownService]:
+    """Resolve the github and markdown services from the active config."""
+    github_service = get_github_service()
+    config_data = await github_service.get_config()
+    config = Config.from_dict(config_data)
+    return github_service, get_markdown_service(config)
+
+
+async def get_cached_posts(include_drafts: bool) -> list[Post]:
+    """Return the cached parsed posts for the audience, building on miss.
+
+    Parsing every post's markdown (including Pygments highlighting) is the
+    expensive part, so one miss parses everything once with drafts included and
+    caches both audience variants: the published list is just the drafts
+    filtered out. Both inherit the cache TTL and are invalidated by the
+    webhook's cache.clear() like every other derived blob. Mirrors
+    services/search.py::get_search_index.
+    """
+    cache = get_cache()
+    key = POSTS_ALL_KEY if include_drafts else POSTS_PUBLISHED_KEY
+    cached = await cache.get(key)
+    if cached is not None:
+        return cached
+
+    github_service, markdown_service = await _build_content_services()
+    posts = await get_all_posts(github_service, markdown_service, include_drafts=True)
+
+    published = [p for p in posts if not p.draft]
+    await cache.set(POSTS_ALL_KEY, posts)
+    await cache.set(POSTS_PUBLISHED_KEY, published)
+    return posts if include_drafts else published
+
+
+async def get_cached_pages(include_hidden: bool) -> list[Page]:
+    """Return the cached parsed pages for the audience, building on miss.
+
+    Same drafts-included-once pattern as get_cached_posts: the visible variant
+    is the hidden pages filtered out. The "all" variant must only be served to
+    admins.
+    """
+    cache = get_cache()
+    key = PAGES_ALL_KEY if include_hidden else PAGES_VISIBLE_KEY
+    cached = await cache.get(key)
+    if cached is not None:
+        return cached
+
+    github_service, markdown_service = await _build_content_services()
+    pages = await get_all_pages(github_service, markdown_service, include_hidden=True)
+
+    visible = [p for p in pages if p.visibility != "hidden"]
+    await cache.set(PAGES_ALL_KEY, pages)
+    await cache.set(PAGES_VISIBLE_KEY, visible)
+    return pages if include_hidden else visible
+
+
+async def warm_content_caches() -> None:
+    """Pre-build both audience variants of posts and pages (webhook/admin warm).
+
+    One call per content type suffices: a miss builds and caches both variants.
+    """
+    await get_cached_posts(include_drafts=True)
+    await get_cached_pages(include_hidden=True)

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -13,11 +13,9 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel
 
-from squishmark.models.content import Config, Post
+from squishmark.models.content import Post
 from squishmark.services.cache import get_cache
-from squishmark.services.content import get_all_posts
-from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
+from squishmark.services.content import get_cached_posts
 
 MIN_QUERY_LENGTH = 2
 DEFAULT_LIMIT = 8
@@ -182,11 +180,12 @@ def search_posts(query: str, posts: list[Post], limit: int = DEFAULT_LIMIT) -> l
 async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     """Return the cached index for the audience, building it on miss.
 
-    Building is the expensive part (get_all_posts re-parses every post's
-    markdown), so one miss parses everything once with drafts included and
-    caches both audience variants — the published index is just the drafts
-    filtered out. Both inherit the cache's TTL and are invalidated by the
-    webhook's cache.clear() like every other derived blob.
+    Building is the expensive part (tokenizing every post body), so one miss
+    indexes everything once with drafts included and caches both audience
+    variants: the published index is just the drafts filtered out. Both inherit
+    the cache's TTL and are invalidated by the webhook's cache.clear() like
+    every other derived blob. The parsed posts come from the shared cached
+    content layer (get_cached_posts), so they are parsed at most once per TTL.
     """
     cache = get_cache()
     key = SEARCH_INDEX_ALL_KEY if include_drafts else SEARCH_INDEX_PUBLISHED_KEY
@@ -194,11 +193,7 @@ async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     if cached is not None:
         return cached
 
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
-    config = Config.from_dict(config_data)
-    markdown_service = get_markdown_service(config)
-    posts = await get_all_posts(github_service, markdown_service, include_drafts=True)
+    posts = await get_cached_posts(include_drafts=True)
 
     all_index = build_search_index(posts)
     published_index = [indexed for indexed in all_index if not indexed.result.draft]

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from jinja2 import Environment, TemplateNotFound
 
 from squishmark.models.content import Config, Page, Pagination, Post
-from squishmark.services.markdown import get_markdown_service
+from squishmark.services.content import get_cached_pages
 from squishmark.services.theme.favicon import FaviconDetector
 from squishmark.services.theme.filters import register_filters
 from squishmark.services.theme.loader import AsyncHybridLoader
@@ -86,19 +86,12 @@ class ThemeEngine:
         alphabetically by title.  The list is truncated to
         ``config.theme.nav_max_pages`` when set.
         """
-        page_files = await self.github_service.list_directory("pages")
-        markdown_service = get_markdown_service(config)
-
-        pages: list[Page] = []
-        for path in page_files:
-            if not path.endswith(".md"):
-                continue
-            file = await self.github_service.get_file(path)
-            if file is None:
-                continue
-            page = markdown_service.parse_page(path, file.content)
-            if page.visibility == "public":
-                pages.append(page)
+        # Reuse the shared cached content layer so pages are parsed at most once
+        # per TTL instead of on every render. The visible variant already
+        # excludes hidden pages; keep the explicit public filter (unlisted pages
+        # stay out of the navbar).
+        cached_pages = await get_cached_pages(include_hidden=False)
+        pages = [p for p in cached_pages if p.visibility == "public"]
 
         # Sort: pages with nav_order first (ascending), then alphabetical by title
         pages.sort(key=lambda p: (p.nav_order is None, p.nav_order or 0, p.title))

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,9 +1,23 @@
 """Tests for content service helpers."""
 
 from datetime import date
+from typing import Any
+
+import pytest
 
 from squishmark.models.content import Post, SiteConfig
-from squishmark.services.content import get_featured_posts
+from squishmark.services.cache import get_cache
+from squishmark.services.content import (
+    PAGES_ALL_KEY,
+    PAGES_VISIBLE_KEY,
+    POSTS_ALL_KEY,
+    POSTS_PUBLISHED_KEY,
+    get_cached_pages,
+    get_cached_posts,
+    get_featured_posts,
+    warm_content_caches,
+)
+from squishmark.services.github import GitHubFile
 
 
 def _make_post(
@@ -55,3 +69,136 @@ class TestGetFeaturedPosts:
         result = get_featured_posts(posts, SiteConfig(featured_max=2))
         assert len(result) == 2
         assert result[0].slug == "post-0"
+
+
+_CONFIG: dict[str, Any] = {"site": {"title": "Test"}, "theme": {"name": "default"}}
+
+
+def _post_md(title: str, *, draft: bool = False) -> str:
+    draft_line = "draft: true\n" if draft else ""
+    return f"---\ntitle: {title}\n{draft_line}---\n\n# {title}\n\nBody.\n"
+
+
+def _page_md(title: str, *, visibility: str = "public") -> str:
+    return f"---\ntitle: {title}\nvisibility: {visibility}\n---\n\n# {title}\n\nBody.\n"
+
+
+class _CountingGitHub:
+    """Fake GitHub service counting get_file calls to prove parse reuse."""
+
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = files
+        self.get_file_calls = 0
+
+    async def get_config(self, use_cache: bool = True) -> dict[str, Any]:
+        return _CONFIG
+
+    async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
+        prefix = f"{path.rstrip('/')}/"
+        return sorted(k for k in self.files if k.startswith(prefix) and "/" not in k[len(prefix) :])
+
+    async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
+        self.get_file_calls += 1
+        content = self.files.get(path)
+        return None if content is None else GitHubFile(path=path, content=content)
+
+
+@pytest.fixture
+def fake_github(monkeypatch: pytest.MonkeyPatch) -> _CountingGitHub:
+    """Install a counting fake as the service the cached layer resolves.
+
+    DEBUG is pinned false so the cache TTL is non-zero (a zero TTL expires
+    entries immediately, which would defeat the reuse assertions).
+    """
+    from squishmark.config import get_settings
+    from squishmark.services.cache import reset_cache
+
+    monkeypatch.setenv("DEBUG", "false")
+    get_settings.cache_clear()
+    reset_cache()
+
+    files = {
+        "posts/2026-01-02-published.md": _post_md("Published"),
+        "posts/2026-01-03-secret.md": _post_md("Secret", draft=True),
+        "pages/about.md": _page_md("About"),
+        "pages/hidden.md": _page_md("Hidden", visibility="hidden"),
+    }
+    fake = _CountingGitHub(files)
+    monkeypatch.setattr("squishmark.services.content.get_github_service", lambda: fake)
+    return fake
+
+
+class TestGetCachedPosts:
+    """Draft gating, audience-variant caching, and invalidation for posts."""
+
+    @pytest.mark.asyncio
+    async def test_published_variant_excludes_drafts(self, fake_github: _CountingGitHub) -> None:
+        published = await get_cached_posts(include_drafts=False)
+        assert [p.slug for p in published] == ["published"]
+
+    @pytest.mark.asyncio
+    async def test_all_variant_includes_drafts(self, fake_github: _CountingGitHub) -> None:
+        all_posts = await get_cached_posts(include_drafts=True)
+        assert {p.slug for p in all_posts} == {"published", "secret"}
+
+    @pytest.mark.asyncio
+    async def test_one_miss_caches_both_variants(self, fake_github: _CountingGitHub) -> None:
+        """A single published miss must also populate the admin variant, so the
+        admin request that follows never re-parses (and never leaks the other
+        way around)."""
+        await get_cached_posts(include_drafts=False)
+        after_first = fake_github.get_file_calls
+        assert after_first > 0
+
+        # The drafts-included variant is served from the same miss: no re-fetch.
+        all_posts = await get_cached_posts(include_drafts=True)
+        assert fake_github.get_file_calls == after_first
+        assert {p.slug for p in all_posts} == {"published", "secret"}
+
+    @pytest.mark.asyncio
+    async def test_repeat_call_does_not_refetch(self, fake_github: _CountingGitHub) -> None:
+        await get_cached_posts(include_drafts=False)
+        after_first = fake_github.get_file_calls
+        await get_cached_posts(include_drafts=False)
+        assert fake_github.get_file_calls == after_first
+
+    @pytest.mark.asyncio
+    async def test_clear_invalidates(self, fake_github: _CountingGitHub) -> None:
+        await get_cached_posts(include_drafts=False)
+        after_first = fake_github.get_file_calls
+        await get_cache().clear()
+        await get_cached_posts(include_drafts=False)
+        assert fake_github.get_file_calls > after_first
+
+
+class TestGetCachedPages:
+    """Hidden gating, audience-variant caching, and invalidation for pages."""
+
+    @pytest.mark.asyncio
+    async def test_visible_variant_excludes_hidden(self, fake_github: _CountingGitHub) -> None:
+        visible = await get_cached_pages(include_hidden=False)
+        assert [p.slug for p in visible] == ["about"]
+
+    @pytest.mark.asyncio
+    async def test_all_variant_includes_hidden(self, fake_github: _CountingGitHub) -> None:
+        all_pages = await get_cached_pages(include_hidden=True)
+        assert {p.slug for p in all_pages} == {"about", "hidden"}
+
+    @pytest.mark.asyncio
+    async def test_one_miss_caches_both_variants(self, fake_github: _CountingGitHub) -> None:
+        await get_cached_pages(include_hidden=False)
+        after_first = fake_github.get_file_calls
+        all_pages = await get_cached_pages(include_hidden=True)
+        assert fake_github.get_file_calls == after_first
+        assert {p.slug for p in all_pages} == {"about", "hidden"}
+
+
+class TestWarmContentCaches:
+    @pytest.mark.asyncio
+    async def test_warm_populates_all_variants(self, fake_github: _CountingGitHub) -> None:
+        await warm_content_caches()
+        cache = get_cache()
+        assert await cache.get(POSTS_ALL_KEY) is not None
+        assert await cache.get(POSTS_PUBLISHED_KEY) is not None
+        assert await cache.get(PAGES_ALL_KEY) is not None
+        assert await cache.get(PAGES_VISIBLE_KEY) is not None

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -150,6 +150,7 @@ class TestAtomFeedEndpoint:
 
         with (
             patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()
@@ -180,6 +181,7 @@ class TestAtomFeedEndpoint:
 
         with (
             patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()
@@ -203,6 +205,7 @@ class TestAtomFeedEndpoint:
 
         with (
             patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()

--- a/tests/test_nav_pages.py
+++ b/tests/test_nav_pages.py
@@ -123,35 +123,27 @@ class TestHiddenPage404:
 
 
 class TestGetNavPages:
-    """Tests for ThemeEngine.get_nav_pages() filtering and sorting."""
+    """Tests for ThemeEngine.get_nav_pages() filtering and sorting.
 
-    def _make_page_content(self, title: str, visibility: str = "public", nav_order: int | None = None) -> str:
-        """Build markdown content with frontmatter."""
-        lines = [f"title: {title}", f"visibility: {visibility}"]
-        if nav_order is not None:
-            lines.append(f"nav_order: {nav_order}")
-        return "---\n" + "\n".join(lines) + "\n---\nContent"
+    get_nav_pages reads the shared cached content layer (get_cached_pages),
+    which already excludes hidden pages, so these tests patch it with the
+    visible variant and assert the engine's own public-filter, sort, and
+    truncation logic.
+    """
+
+    def _page(self, title: str, visibility: str = "public", nav_order: int | None = None) -> Page:
+        return Page(slug=title.lower(), title=title, visibility=visibility, nav_order=nav_order)
 
     @pytest.mark.asyncio
     async def test_filters_public_only(self):
-        """Only public pages should appear in nav."""
+        """Only public pages should appear in nav (unlisted excluded)."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        mock_github = AsyncMock()
-        mock_github.list_directory.return_value = [
-            "pages/about.md",
-            "pages/secret.md",
-            "pages/draft.md",
-        ]
-        mock_github.get_file.side_effect = [
-            MagicMock(content=self._make_page_content("About", "public")),
-            MagicMock(content=self._make_page_content("Secret", "hidden")),
-            MagicMock(content=self._make_page_content("Draft", "unlisted")),
-        ]
-
-        engine = ThemeEngine(mock_github)
+        visible = [self._page("About", "public"), self._page("Draft", "unlisted")]
+        engine = ThemeEngine(AsyncMock())
         config = Config()
-        pages = await engine.get_nav_pages(config)
+        with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
+            pages = await engine.get_nav_pages(config)
 
         assert len(pages) == 1
         assert pages[0].title == "About"
@@ -161,23 +153,16 @@ class TestGetNavPages:
         """Pages sort by nav_order ascending (nulls last), then title."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        mock_github = AsyncMock()
-        mock_github.list_directory.return_value = [
-            "pages/contact.md",
-            "pages/about.md",
-            "pages/projects.md",
-            "pages/blog.md",
+        visible = [
+            self._page("Contact", nav_order=2),
+            self._page("About", nav_order=1),
+            self._page("Projects"),
+            self._page("Blog"),
         ]
-        mock_github.get_file.side_effect = [
-            MagicMock(content=self._make_page_content("Contact", nav_order=2)),
-            MagicMock(content=self._make_page_content("About", nav_order=1)),
-            MagicMock(content=self._make_page_content("Projects")),
-            MagicMock(content=self._make_page_content("Blog")),
-        ]
-
-        engine = ThemeEngine(mock_github)
+        engine = ThemeEngine(AsyncMock())
         config = Config()
-        pages = await engine.get_nav_pages(config)
+        with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
+            pages = await engine.get_nav_pages(config)
 
         titles = [p.title for p in pages]
         # nav_order 1, nav_order 2, then alphabetical nulls
@@ -188,21 +173,11 @@ class TestGetNavPages:
         """nav_max_pages should limit the number of pages returned."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        mock_github = AsyncMock()
-        mock_github.list_directory.return_value = [
-            "pages/a.md",
-            "pages/b.md",
-            "pages/c.md",
-        ]
-        mock_github.get_file.side_effect = [
-            MagicMock(content=self._make_page_content("A")),
-            MagicMock(content=self._make_page_content("B")),
-            MagicMock(content=self._make_page_content("C")),
-        ]
-
-        engine = ThemeEngine(mock_github)
+        visible = [self._page("A"), self._page("B"), self._page("C")]
+        engine = ThemeEngine(AsyncMock())
         config = Config(theme=ThemeConfig(nav_max_pages=2))
-        pages = await engine.get_nav_pages(config)
+        with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
+            pages = await engine.get_nav_pages(config)
 
         assert len(pages) == 2
 
@@ -211,11 +186,9 @@ class TestGetNavPages:
         """Should return empty list when no pages exist."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        mock_github = AsyncMock()
-        mock_github.list_directory.return_value = []
-
-        engine = ThemeEngine(mock_github)
+        engine = ThemeEngine(AsyncMock())
         config = Config()
-        pages = await engine.get_nav_pages(config)
+        with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=[])):
+            pages = await engine.get_nav_pages(config)
 
         assert pages == []

--- a/tests/test_notes_rendering.py
+++ b/tests/test_notes_rendering.py
@@ -35,6 +35,7 @@ class TestPostNotesRendering:
 
         with (
             patch("squishmark.routers.posts.get_github_service") as mock_get_github,
+            patch("squishmark.services.content.get_github_service", mock_get_github),
             patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
@@ -61,6 +62,7 @@ class TestPostNotesRendering:
 
         with (
             patch("squishmark.routers.posts.get_github_service") as mock_get_github,
+            patch("squishmark.services.content.get_github_service", mock_get_github),
             patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=True),
@@ -87,6 +89,7 @@ class TestPostNotesRendering:
 
         with (
             patch("squishmark.routers.posts.get_github_service") as mock_get_github,
+            patch("squishmark.services.content.get_github_service", mock_get_github),
             patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
@@ -114,6 +117,7 @@ class TestPostNotesRendering:
 
         with (
             patch("squishmark.routers.posts.get_github_service") as mock_get_github,
+            patch("squishmark.services.content.get_github_service", mock_get_github),
             patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
@@ -145,6 +149,7 @@ class TestPostNotesRendering:
 
         with (
             patch("squishmark.routers.posts.get_github_service") as mock_get_github,
+            patch("squishmark.services.content.get_github_service", mock_get_github),
             patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
@@ -177,6 +182,7 @@ class TestPageNotesRendering:
 
         with (
             patch("squishmark.routers.pages.get_github_service") as mock_get_github,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
             patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
@@ -202,6 +208,7 @@ class TestPageNotesRendering:
 
         with (
             patch("squishmark.routers.pages.get_github_service") as mock_get_github,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
             patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=True),
@@ -227,6 +234,7 @@ class TestPageNotesRendering:
 
         with (
             patch("squishmark.routers.pages.get_github_service") as mock_get_github,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
             patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
@@ -253,6 +261,7 @@ class TestPageNotesRendering:
 
         with (
             patch("squishmark.routers.pages.get_github_service") as mock_get_github,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
             patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
@@ -282,6 +291,7 @@ class TestPageNotesRendering:
 
         with (
             patch("squishmark.routers.pages.get_github_service") as mock_get_github,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
             patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -211,6 +211,7 @@ class TestSitemapEndpoint:
 
         with (
             patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()
@@ -257,6 +258,7 @@ class TestSitemapEndpoint:
 
         with (
             patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()
@@ -281,6 +283,7 @@ class TestRobotsEndpoint:
 
         with (
             patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
+            patch("squishmark.services.content.get_github_service", return_value=mock_github),
             patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
         ):
             mock_cache = AsyncMock()


### PR DESCRIPTION
Closes #107

Rendering any page re-fetched and re-parsed every post (and nav pages) on each request. This adds a cached parsed-content layer mirroring the existing search-index pattern:

- `get_cached_posts` / `get_cached_pages` in `services/content.py`: one miss parses everything once with drafts/hidden included and caches both audience variants; the published/visible variant is a filter of the full one
- Posts, pages, feed, and sitemap routes plus `ThemeEngine.get_nav_pages` read the cached layer; the search index now builds from the shared cached posts, so content is parsed at most once per TTL
- Webhook and admin cache refresh call `warm_content_caches()` so the first request after a push is not cold
- Draft/hidden gating unchanged: the drafts-included variant is only returned for admin requests, same property as the search index

Tests cover gating, one-miss-builds-both-variants (via fetch-call counting), reuse, and `cache.clear()` invalidation. Checks green (337 tests). Smoke-tested posts, post detail, page, feed, sitemap, and search endpoints against a dev server on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)