### PR TITLE
refactor(services): replace module singletons with DI container

### DIFF
--- a/src/squishmark/dependencies.py
+++ b/src/squishmark/dependencies.py
@@ -6,11 +6,29 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Request
 
 from squishmark.config import Settings, get_settings
+from squishmark.services.container import Services
+from squishmark.services.theme import ThemeEngine
 
 logger = logging.getLogger(__name__)
 
 # Type alias for settings dependency
 SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+def get_services(request: Request) -> Services:
+    """Return the service container built in the lifespan and hung on app.state."""
+    return request.app.state.services
+
+
+ServicesDep = Annotated[Services, Depends(get_services)]
+
+
+def get_theme_engine(request: Request) -> ThemeEngine:
+    """Return the theme engine built in the lifespan and hung on app.state."""
+    return request.app.state.theme_engine
+
+
+ThemeEngineDep = Annotated[ThemeEngine, Depends(get_theme_engine)]
 
 
 def is_admin(request: Request) -> bool:

--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -50,7 +50,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     theme_engine = ThemeEngine(services)
     await theme_engine.load_custom_templates()
     app.state.theme_engine = theme_engine
-    logger.info("Theme engine initialized")
+    config = Config.from_dict(await services.github.get_config())
+    logger.info("Theme engine initialized (configured theme: %s)", config.theme.name)
 
     # Start live reload watcher in debug mode
     if settings.debug:

--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -13,8 +13,9 @@ from squishmark.models.content import Config
 from squishmark.models.db import close_db, init_db
 from squishmark.routers import admin, assets, auth, feed, pages, posts, search, seo, webhooks
 from squishmark.services.analytics_middleware import register_analytics_middleware
-from squishmark.services.github import get_github_service, shutdown_github_service
-from squishmark.services.theme import get_theme_engine, reset_theme_engine
+from squishmark.services.container import build_services
+from squishmark.services.livereload import LiveReloadService
+from squishmark.services.theme import ThemeEngine
 
 # Configure logging
 logging.basicConfig(
@@ -39,34 +40,32 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await init_db()
     logger.info("Database initialized")
 
-    # Pre-initialize services
-    github_service = get_github_service()
+    # Build the service container and hang it on app.state for DI.
+    services = build_services(settings)
+    app.state.services = services
 
-    # Load custom templates if any
-    await get_theme_engine(github_service)
+    # Theme engine loads custom templates from the content repo (async), so it
+    # is built here rather than in build_services. It holds a back-reference to
+    # the container so get_nav_pages can reach the cached content layer.
+    theme_engine = ThemeEngine(services.github, services=services)
+    await theme_engine.load_custom_templates()
+    app.state.theme_engine = theme_engine
     logger.info("Theme engine initialized")
 
     # Start live reload watcher in debug mode
     if settings.debug:
-        from squishmark.services.livereload import get_livereload_service
-
-        livereload = get_livereload_service()
-        await livereload.start()
+        services.livereload = LiveReloadService()
+        await services.livereload.start()
 
     yield
 
     # Shutdown
     logger.info("Shutting down SquishMark")
 
-    if settings.debug:
-        from squishmark.services.livereload import get_livereload_service, reset_livereload_service
+    if settings.debug and services.livereload is not None:
+        await services.livereload.stop()
 
-        livereload = get_livereload_service()
-        await livereload.stop()
-        reset_livereload_service()
-
-    await shutdown_github_service()
-    reset_theme_engine()
+    await services.github.close()
     await close_db()
 
 
@@ -91,10 +90,10 @@ def create_app() -> FastAPI:
         if "text/html" in accept and exc.status_code == 404:
             # Return HTML 404 page
             try:
-                github_service = get_github_service()
-                config_data = await github_service.get_config()
+                services = request.app.state.services
+                config_data = await services.github.get_config()
                 config = Config.from_dict(config_data)
-                theme_engine = await get_theme_engine()
+                theme_engine = request.app.state.theme_engine
                 html = await theme_engine.render_404(config)
                 return HTMLResponse(content=html, status_code=404)
             except Exception:
@@ -150,13 +149,14 @@ def create_app() -> FastAPI:
 
     # LiveReload WebSocket endpoint and middleware (debug mode only)
     if settings.debug:
-        from squishmark.services.livereload import LiveReloadMiddleware, get_livereload_service
+        from squishmark.services.livereload import LiveReloadMiddleware
 
         @app.websocket("/dev/livereload")
         async def livereload_ws(websocket: WebSocket) -> None:
             """WebSocket endpoint for theme live reload notifications."""
-            livereload = get_livereload_service()
-            await livereload.handle_websocket(websocket)
+            livereload = websocket.app.state.services.livereload
+            if livereload is not None:
+                await livereload.handle_websocket(websocket)
 
         app.add_middleware(LiveReloadMiddleware)
 

--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -47,7 +47,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Theme engine loads custom templates from the content repo (async), so it
     # is built here rather than in build_services. It holds a back-reference to
     # the container so get_nav_pages can reach the cached content layer.
-    theme_engine = ThemeEngine(services.github, services=services)
+    theme_engine = ThemeEngine(services)
     await theme_engine.load_custom_templates()
     app.state.theme_engine = theme_engine
     logger.info("Theme engine initialized")

--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -13,17 +13,15 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from squishmark.config import get_settings
-from squishmark.dependencies import AdminUser, is_htmx
+from squishmark.dependencies import AdminUser, ServicesDep, ThemeEngineDep, is_htmx
 from squishmark.models.content import Config
 from squishmark.models.db import Note, get_db_session
 from squishmark.services.analytics import AnalyticsService
-from squishmark.services.cache import get_cache
 from squishmark.services.content import warm_content_caches
 from squishmark.services.csrf import get_or_create_csrf_token, verify_csrf_token
-from squishmark.services.github import get_github_service
 from squishmark.services.notes import NotesService
 from squishmark.services.search import warm_search_indexes
-from squishmark.services.theme import get_theme_engine, reset_theme_engine
+from squishmark.services.theme import ThemeEngine
 
 logger = logging.getLogger(__name__)
 
@@ -99,12 +97,15 @@ def _to_note_response(note: Note) -> NoteResponse:
     )
 
 
-async def _render_note_partial(template_name: str, **context: Any) -> str:
+async def _render_note_partial(
+    services: ServicesDep,
+    theme_engine: ThemeEngine,
+    template_name: str,
+    **context: Any,
+) -> str:
     """Render a notes admin partial using the active site theme."""
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     theme_name = Config.from_dict(config_data).theme.name
-    theme_engine = await get_theme_engine(github_service)
     return theme_engine.render_partial(template_name, theme_override=theme_name, **context)
 
 
@@ -179,12 +180,12 @@ async def admin_dashboard(
     request: Request,
     admin: AdminUser,
     session: DbSession,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
 ) -> HTMLResponse:
     """Render the admin dashboard."""
-    github_service = get_github_service()
-
     # Get config
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
     # Get analytics
@@ -196,11 +197,10 @@ async def admin_dashboard(
     notes = await notes_service.get_all()
 
     # Get cache info
-    cache = get_cache()
+    cache = services.cache
 
     # Render admin template
     csrf_token = get_or_create_csrf_token(request)
-    theme_engine = await get_theme_engine(github_service)
     try:
         html = await theme_engine.render_admin(
             config,
@@ -271,6 +271,8 @@ async def create_note(
     request: Request,
     admin: AdminUser,
     session: DbSession,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
 ) -> NoteResponse | HTMLResponse:
     """Create a new note. Returns an HTML partial for HTMX, JSON otherwise."""
     note_data = await parse_note_create(request)
@@ -283,7 +285,7 @@ async def create_note(
     )
     response = _to_note_response(note)
     if is_htmx(request):
-        html = await _render_note_partial("admin/_note_item.html", note=response)
+        html = await _render_note_partial(services, theme_engine, "admin/_note_item.html", note=response)
         return HTMLResponse(content=html, status_code=201)
     return response
 
@@ -297,6 +299,8 @@ async def update_note(
     request: Request,
     admin: AdminUser,
     session: DbSession,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     note_id: int,
 ) -> NoteResponse | HTMLResponse:
     """Update a note. Returns an HTML partial for HTMX, JSON otherwise."""
@@ -312,7 +316,7 @@ async def update_note(
         raise HTTPException(status_code=404, detail="Note not found")
     response = _to_note_response(note)
     if is_htmx(request):
-        html = await _render_note_partial("admin/_note_item.html", note=response)
+        html = await _render_note_partial(services, theme_engine, "admin/_note_item.html", note=response)
         return HTMLResponse(content=html)
     return response
 
@@ -343,6 +347,8 @@ async def delete_note(
 async def edit_note_form(
     admin: AdminUser,
     session: DbSession,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     note_id: int,
 ) -> HTMLResponse:
     """Return the inline edit form for a note (HTMX swap target)."""
@@ -351,7 +357,9 @@ async def edit_note_form(
     note = await notes_service.get_by_id(note_id)
     if note is None:
         raise HTTPException(status_code=404, detail="Note not found")
-    html = await _render_note_partial("admin/_note_edit_form.html", note=_to_note_response(note))
+    html = await _render_note_partial(
+        services, theme_engine, "admin/_note_edit_form.html", note=_to_note_response(note)
+    )
     return HTMLResponse(content=html)
 
 
@@ -359,6 +367,8 @@ async def edit_note_form(
 async def view_note(
     admin: AdminUser,
     session: DbSession,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     note_id: int,
 ) -> HTMLResponse:
     """Return the read-only note row (used by the edit form's Cancel button)."""
@@ -367,7 +377,7 @@ async def view_note(
     note = await notes_service.get_by_id(note_id)
     if note is None:
         raise HTTPException(status_code=404, detail="Note not found")
-    html = await _render_note_partial("admin/_note_item.html", note=_to_note_response(note))
+    html = await _render_note_partial(services, theme_engine, "admin/_note_item.html", note=_to_note_response(note))
     return HTMLResponse(content=html)
 
 
@@ -375,19 +385,22 @@ async def view_note(
 @router.post("/cache/refresh", dependencies=[Depends(verify_csrf_token)])
 async def refresh_cache(
     admin: AdminUser,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
 ) -> CacheRefreshResponse:
     """Clear and refresh the content cache."""
+    del admin  # auth side-effect only (AdminUser dependency)
     start = time.time()
 
     # Clear the cache
-    cache = get_cache()
+    cache = services.cache
     cleared = await cache.clear()
 
-    # Reset theme engine to reload templates
-    reset_theme_engine()
+    # Reload theme engine templates and favicon detection
+    await theme_engine.reload()
 
     # Warm the cache by fetching content
-    github_service = get_github_service()
+    github_service = services.github
 
     # Fetch config
     await github_service.get_config(use_cache=True)
@@ -402,12 +415,9 @@ async def refresh_cache(
     for path in page_files:
         await github_service.get_file(path, use_cache=True)
 
-    # Reload theme engine
-    await get_theme_engine(github_service)
-
     # Pre-parse posts, pages, and search indexes so the next request isn't cold
-    await warm_content_caches()
-    await warm_search_indexes()
+    await warm_content_caches(services)
+    await warm_search_indexes(services)
 
     duration_ms = (time.time() - start) * 1000
     warmed = cache.size

--- a/src/squishmark/routers/assets.py
+++ b/src/squishmark/routers/assets.py
@@ -7,9 +7,8 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse, Response
 
 from squishmark.config import get_settings
+from squishmark.dependencies import ServicesDep
 from squishmark.models.content import Config
-from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
 
 router = APIRouter(tags=["assets"])
 
@@ -22,13 +21,11 @@ VALID_THEME_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 # Favicon endpoint - browsers request this automatically
 @router.get("/favicon.ico")
-async def serve_favicon() -> Response:
+async def serve_favicon(services: ServicesDep) -> Response:
     """Serve favicon from content repository."""
-    github_service = get_github_service()
-
     # Try common favicon locations in order of preference
     for path in ["static/favicon.ico", "static/favicon.png", "static/favicon.svg"]:
-        file = await github_service.get_binary_file(path)
+        file = await services.github.get_binary_file(path)
         if file:
             return Response(
                 content=file.content,
@@ -41,12 +38,11 @@ async def serve_favicon() -> Response:
 
 # Dynamic Pygments CSS - generates syntax highlighting styles from config
 @router.get("/pygments.css")
-async def serve_pygments_css() -> Response:
+async def serve_pygments_css(services: ServicesDep) -> Response:
     """Serve dynamically generated Pygments CSS based on configured style."""
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
-    md_service = get_markdown_service(config)
+    md_service = services.markdown_for(config)
     css = md_service.get_pygments_css()
     return Response(
         content=css,
@@ -56,7 +52,7 @@ async def serve_pygments_css() -> Response:
 
 
 @router.get("/static/user/{path:path}")
-async def serve_user_static(path: str) -> Response:
+async def serve_user_static(services: ServicesDep, path: str) -> Response:
     """Serve static files from the user's content repository."""
     # Security: reject path traversal (matters in local content mode)
     if ".." in path or "\\" in path or path.startswith("/"):
@@ -67,8 +63,7 @@ async def serve_user_static(path: str) -> Response:
     if ext not in ALLOWED_STATIC_EXTENSIONS:
         raise HTTPException(status_code=404, detail="File not found")
 
-    github_service = get_github_service()
-    file = await github_service.get_binary_file(f"static/{path}")
+    file = await services.github.get_binary_file(f"static/{path}")
 
     if file is None:
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/squishmark/routers/feed.py
+++ b/src/squishmark/routers/feed.py
@@ -6,10 +6,9 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from fastapi import APIRouter
 from fastapi.responses import Response
 
+from squishmark.dependencies import ServicesDep
 from squishmark.models.content import Config, Post
-from squishmark.services.cache import get_cache
 from squishmark.services.content import get_cached_posts
-from squishmark.services.github import get_github_service
 
 router = APIRouter(tags=["feed"])
 
@@ -77,20 +76,19 @@ FEED_CACHE_KEY = "feed:atom"
 
 
 @router.get("/feed.xml")
-async def atom_feed() -> Response:
+async def atom_feed(services: ServicesDep) -> Response:
     """Serve the Atom 1.0 feed."""
-    cache = get_cache()
+    cache = services.cache
 
     # Return cached feed if available
     cached_xml = await cache.get(FEED_CACHE_KEY)
     if cached_xml is not None:
         return Response(content=cached_xml, media_type="application/atom+xml; charset=utf-8")
 
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
-    posts = await get_cached_posts(include_drafts=False)
+    posts = await get_cached_posts(services, include_drafts=False)
     posts = posts[:20]  # Limit to 20 most recent
 
     xml_bytes = _build_atom_feed(config, posts)

--- a/src/squishmark/routers/pages.py
+++ b/src/squishmark/routers/pages.py
@@ -4,14 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from squishmark.dependencies import is_admin
+from squishmark.dependencies import ServicesDep, ThemeEngineDep, is_admin
 from squishmark.models.content import Config
 from squishmark.models.db import get_db_session
 from squishmark.services.content import get_cached_posts, get_featured_posts
-from squishmark.services.github import get_github_service
-from squishmark.services.markdown import get_markdown_service
 from squishmark.services.notes import NotesService
-from squishmark.services.theme import get_theme_engine
 
 router = APIRouter(tags=["pages"])
 
@@ -19,6 +16,8 @@ router = APIRouter(tags=["pages"])
 @router.get("/{slug}", response_class=HTMLResponse)
 async def get_page(
     request: Request,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     slug: str,
     db: AsyncSession = Depends(get_db_session),
 ) -> HTMLResponse:
@@ -28,18 +27,16 @@ async def get_page(
     This route has lower priority than /posts routes and is designed
     to be a catch-all for pages like /about, /contact, etc.
     """
-    github_service = get_github_service()
-
     # Get config
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
     # Get markdown service with config
-    markdown_service = get_markdown_service(config)
+    markdown_service = services.markdown_for(config)
 
     # Try to find the page
     page_path = f"pages/{slug}.md"
-    file = await github_service.get_file(page_path)
+    file = await services.github.get_file(page_path)
 
     if file is None:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -57,11 +54,10 @@ async def get_page(
     notes = await notes_service.get_for_path(f"/{slug}", include_private=admin)
 
     # Featured posts for template context (published only, shown to everyone)
-    all_posts = await get_cached_posts(include_drafts=False)
+    all_posts = await get_cached_posts(services, include_drafts=False)
     featured = get_featured_posts(all_posts, config.site)
 
     # Render
-    theme_engine = await get_theme_engine(github_service)
     html = await theme_engine.render_page(config, page, notes, featured_posts=featured)
 
     return HTMLResponse(content=html)

--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -4,13 +4,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from squishmark.dependencies import is_admin
+from squishmark.dependencies import ServicesDep, ThemeEngineDep, is_admin
 from squishmark.models.content import Config, Pagination
 from squishmark.models.db import get_db_session
 from squishmark.services.content import build_series_context, get_cached_posts, get_featured_posts
-from squishmark.services.github import get_github_service
 from squishmark.services.notes import NotesService
-from squishmark.services.theme import get_theme_engine
 
 router = APIRouter(prefix="/posts", tags=["posts"])
 
@@ -18,18 +16,18 @@ router = APIRouter(prefix="/posts", tags=["posts"])
 @router.get("", response_class=HTMLResponse)
 async def list_posts(
     request: Request,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     page: int = Query(1, ge=1),
 ) -> HTMLResponse:
     """List all published posts with pagination."""
-    github_service = get_github_service()
-
     # Get config
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
     # Get all posts (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_cached_posts(include_drafts=include_drafts)
+    all_posts = await get_cached_posts(services, include_drafts=include_drafts)
 
     # Paginate
     per_page = config.posts.per_page
@@ -54,7 +52,6 @@ async def list_posts(
     featured = get_featured_posts(all_posts, config.site)
 
     # Render
-    theme_engine = await get_theme_engine(github_service)
     html = await theme_engine.render_index(config, posts, pagination, featured_posts=featured)
 
     return HTMLResponse(content=html)
@@ -63,19 +60,19 @@ async def list_posts(
 @router.get("/{slug}", response_class=HTMLResponse)
 async def get_post(
     request: Request,
+    services: ServicesDep,
+    theme_engine: ThemeEngineDep,
     slug: str,
     db: AsyncSession = Depends(get_db_session),
 ) -> HTMLResponse:
     """Get a single post by slug."""
-    github_service = get_github_service()
-
     # Get config
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
     # Get all posts and find the matching one (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_cached_posts(include_drafts=include_drafts)
+    all_posts = await get_cached_posts(services, include_drafts=include_drafts)
 
     post = next((p for p in all_posts if p.slug == slug), None)
 
@@ -94,7 +91,6 @@ async def get_post(
     series_context = build_series_context(post, all_posts)
 
     # Render
-    theme_engine = await get_theme_engine(github_service)
     html = await theme_engine.render_post(
         config,
         post,

--- a/src/squishmark/routers/search.py
+++ b/src/squishmark/routers/search.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 
-from squishmark.dependencies import is_admin
+from squishmark.dependencies import ServicesDep, is_admin
 from squishmark.services.search import (
     DEFAULT_LIMIT,
     MIN_QUERY_LENGTH,
@@ -15,7 +15,7 @@ router = APIRouter(tags=["search"])
 
 
 @router.get("/search")
-async def search(request: Request, q: str = Query("", max_length=200)) -> JSONResponse:
+async def search(request: Request, services: ServicesDep, q: str = Query("", max_length=200)) -> JSONResponse:
     """Search posts by keyword; admins also match drafts.
 
     Short or empty queries return an empty result set with 200 (the client
@@ -26,7 +26,7 @@ async def search(request: Request, q: str = Query("", max_length=200)) -> JSONRe
     results: list[dict] = []
 
     if len(query) >= MIN_QUERY_LENGTH:
-        index = await get_search_index(include_drafts=is_admin(request))
+        index = await get_search_index(services, include_drafts=is_admin(request))
         results = [r.model_dump(mode="json") for r in query_index(query, index, limit=DEFAULT_LIMIT)]
 
     return JSONResponse(

--- a/src/squishmark/routers/seo.py
+++ b/src/squishmark/routers/seo.py
@@ -6,10 +6,9 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from fastapi import APIRouter
 from fastapi.responses import Response
 
+from squishmark.dependencies import ServicesDep
 from squishmark.models.content import Config, Page, Post
-from squishmark.services.cache import get_cache
 from squishmark.services.content import get_cached_pages, get_cached_posts
-from squishmark.services.github import get_github_service
 
 router = APIRouter(tags=["seo"])
 
@@ -68,20 +67,19 @@ def _build_robots_txt(config: Config) -> str:
 
 
 @router.get("/sitemap.xml")
-async def sitemap_xml() -> Response:
+async def sitemap_xml(services: ServicesDep) -> Response:
     """Serve the XML sitemap."""
-    cache = get_cache()
+    cache = services.cache
 
     cached = await cache.get(SITEMAP_CACHE_KEY)
     if cached is not None:
         return Response(content=cached, media_type="application/xml; charset=utf-8")
 
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
-    posts = await get_cached_posts(include_drafts=False)
-    pages = await get_cached_pages(include_hidden=False)
+    posts = await get_cached_posts(services, include_drafts=False)
+    pages = await get_cached_pages(services, include_hidden=False)
 
     xml_bytes = _build_sitemap(config, posts, pages)
     await cache.set(SITEMAP_CACHE_KEY, xml_bytes)
@@ -89,16 +87,15 @@ async def sitemap_xml() -> Response:
 
 
 @router.get("/robots.txt")
-async def robots_txt() -> Response:
+async def robots_txt(services: ServicesDep) -> Response:
     """Serve robots.txt."""
-    cache = get_cache()
+    cache = services.cache
 
     cached = await cache.get(ROBOTS_CACHE_KEY)
     if cached is not None:
         return Response(content=cached, media_type="text/plain; charset=utf-8")
 
-    github_service = get_github_service()
-    config_data = await github_service.get_config()
+    config_data = await services.github.get_config()
     config = Config.from_dict(config_data)
 
     content = _build_robots_txt(config)

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -6,11 +6,9 @@ import hmac
 from fastapi import APIRouter, HTTPException, Request
 
 from squishmark.config import get_settings
-from squishmark.services.cache import get_cache
+from squishmark.dependencies import ServicesDep, ThemeEngineDep
 from squishmark.services.content import warm_content_caches
-from squishmark.services.github import get_github_service
 from squishmark.services.search import warm_search_indexes
-from squishmark.services.theme import get_theme_engine, reset_theme_engine
 
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 
@@ -30,7 +28,7 @@ def verify_github_signature(payload: bytes, signature: str, secret: str) -> bool
 
 
 @router.post("/github")
-async def github_webhook(request: Request) -> dict:
+async def github_webhook(request: Request, services: ServicesDep, theme_engine: ThemeEngineDep) -> dict:
     """
     Handle GitHub webhook for automatic cache refresh.
 
@@ -67,14 +65,14 @@ async def github_webhook(request: Request) -> dict:
         return {"status": "ignored", "event": event}
 
     # Refresh cache
-    cache = get_cache()
+    cache = services.cache
     cleared = await cache.clear()
 
-    # Reset theme engine
-    reset_theme_engine()
+    # Reload theme engine templates and favicon detection
+    await theme_engine.reload()
 
     # Warm the cache
-    github_service = get_github_service()
+    github_service = services.github
 
     # Fetch config
     await github_service.get_config(use_cache=True)
@@ -89,14 +87,11 @@ async def github_webhook(request: Request) -> dict:
     for path in page_files:
         await github_service.get_file(path, use_cache=True)
 
-    # Reload theme engine
-    await get_theme_engine(github_service)
-
     # Pre-parse posts and pages so the first render after a push isn't cold
-    await warm_content_caches()
+    await warm_content_caches(services)
 
     # Pre-build both search index variants so the first search isn't cold
-    await warm_search_indexes()
+    await warm_search_indexes(services)
 
     return {
         "status": "ok",

--- a/src/squishmark/services/cache.py
+++ b/src/squishmark/services/cache.py
@@ -68,25 +68,3 @@ class Cache:
     def size(self) -> int:
         """Return the current number of entries in the cache."""
         return len(self._store)
-
-
-# Global cache instance
-_cache: Cache | None = None
-
-
-def get_cache() -> Cache:
-    """Get the global cache instance."""
-    global _cache
-    if _cache is None:
-        from squishmark.config import get_settings
-
-        settings = get_settings()
-        ttl = 0 if settings.debug else settings.cache_ttl_seconds
-        _cache = Cache(ttl_seconds=ttl)
-    return _cache
-
-
-def reset_cache() -> None:
-    """Reset the global cache instance. Useful for testing."""
-    global _cache
-    _cache = None

--- a/src/squishmark/services/container.py
+++ b/src/squishmark/services/container.py
@@ -1,0 +1,50 @@
+"""Service container: the app's long-lived services, built once per app.
+
+Constructed in the FastAPI lifespan handler and hung on ``app.state`` so routes
+and other dependencies resolve services via ``Depends`` (see dependencies.py)
+instead of module-level singletons.
+"""
+
+from dataclasses import dataclass
+
+from squishmark.config import Settings
+from squishmark.models.content import Config
+from squishmark.services.cache import Cache
+from squishmark.services.github import GitHubService
+from squishmark.services.livereload import LiveReloadService
+from squishmark.services.markdown import MarkdownService
+
+
+@dataclass
+class Services:
+    """Bundle of the app's shared services, passed where DI is needed."""
+
+    settings: Settings
+    cache: Cache
+    github: GitHubService
+    livereload: LiveReloadService | None = None
+    _markdown: MarkdownService | None = None
+
+    def markdown_for(self, config: Config) -> MarkdownService:
+        """Return the markdown service, building it once from the first config.
+
+        The pygments_style is fixed by the first config seen and reused for the
+        app's life (issue #109 revisits this): behavior matches the previous
+        module-global get_markdown_service.
+        """
+        if self._markdown is None:
+            self._markdown = MarkdownService(pygments_style=config.theme.pygments_style)
+        return self._markdown
+
+
+def create_github_service(settings: Settings, cache: Cache) -> GitHubService:
+    """Construct the GitHub content service (patched in tests to inject a fake)."""
+    return GitHubService(settings, cache)
+
+
+def build_services(settings: Settings) -> Services:
+    """Construct the long-lived services for the app (called from the lifespan)."""
+    # Debug uses a zero TTL so content edits show up immediately.
+    cache = Cache(ttl_seconds=0 if settings.debug else settings.cache_ttl_seconds)
+    github = create_github_service(settings, cache)
+    return Services(settings=settings, cache=cache, github=github)

--- a/src/squishmark/services/content.py
+++ b/src/squishmark/services/content.py
@@ -4,9 +4,9 @@ import datetime
 from typing import Any
 
 from squishmark.models.content import Config, Page, Post, SiteConfig
-from squishmark.services.cache import get_cache
-from squishmark.services.github import GitHubService, get_github_service
-from squishmark.services.markdown import MarkdownService, get_markdown_service
+from squishmark.services.container import Services
+from squishmark.services.github import GitHubService
+from squishmark.services.markdown import MarkdownService
 
 # Audience-separated cache keys. The "all" variants include drafts (posts) and
 # hidden pages, so they must only ever be served to admins: sharing a key would
@@ -141,15 +141,15 @@ async def get_all_pages(
     return pages
 
 
-async def _build_content_services() -> tuple[GitHubService, MarkdownService]:
+async def _build_content_services(services: Services) -> tuple[GitHubService, MarkdownService]:
     """Resolve the github and markdown services from the active config."""
-    github_service = get_github_service()
+    github_service = services.github
     config_data = await github_service.get_config()
     config = Config.from_dict(config_data)
-    return github_service, get_markdown_service(config)
+    return github_service, services.markdown_for(config)
 
 
-async def get_cached_posts(include_drafts: bool) -> list[Post]:
+async def get_cached_posts(services: Services, include_drafts: bool) -> list[Post]:
     """Return the cached parsed posts for the audience, building on miss.
 
     Parsing every post's markdown (including Pygments highlighting) is the
@@ -159,13 +159,13 @@ async def get_cached_posts(include_drafts: bool) -> list[Post]:
     webhook's cache.clear() like every other derived blob. Mirrors
     services/search.py::get_search_index.
     """
-    cache = get_cache()
+    cache = services.cache
     key = POSTS_ALL_KEY if include_drafts else POSTS_PUBLISHED_KEY
     cached = await cache.get(key)
     if cached is not None:
         return cached
 
-    github_service, markdown_service = await _build_content_services()
+    github_service, markdown_service = await _build_content_services(services)
     posts = await get_all_posts(github_service, markdown_service, include_drafts=True)
 
     published = [p for p in posts if not p.draft]
@@ -174,20 +174,20 @@ async def get_cached_posts(include_drafts: bool) -> list[Post]:
     return posts if include_drafts else published
 
 
-async def get_cached_pages(include_hidden: bool) -> list[Page]:
+async def get_cached_pages(services: Services, include_hidden: bool) -> list[Page]:
     """Return the cached parsed pages for the audience, building on miss.
 
     Same drafts-included-once pattern as get_cached_posts: the visible variant
     is the hidden pages filtered out. The "all" variant must only be served to
     admins.
     """
-    cache = get_cache()
+    cache = services.cache
     key = PAGES_ALL_KEY if include_hidden else PAGES_VISIBLE_KEY
     cached = await cache.get(key)
     if cached is not None:
         return cached
 
-    github_service, markdown_service = await _build_content_services()
+    github_service, markdown_service = await _build_content_services(services)
     pages = await get_all_pages(github_service, markdown_service, include_hidden=True)
 
     visible = [p for p in pages if p.visibility != "hidden"]
@@ -196,10 +196,10 @@ async def get_cached_pages(include_hidden: bool) -> list[Page]:
     return pages if include_hidden else visible
 
 
-async def warm_content_caches() -> None:
+async def warm_content_caches(services: Services) -> None:
     """Pre-build both audience variants of posts and pages (webhook/admin warm).
 
     One call per content type suffices: a miss builds and caches both variants.
     """
-    await get_cached_posts(include_drafts=True)
-    await get_cached_pages(include_hidden=True)
+    await get_cached_posts(services, include_drafts=True)
+    await get_cached_pages(services, include_hidden=True)

--- a/src/squishmark/services/github.py
+++ b/src/squishmark/services/github.py
@@ -9,7 +9,7 @@ from typing import Any
 import httpx
 
 from squishmark.config import Settings, parse_file_url
-from squishmark.services.cache import Cache, get_cache
+from squishmark.services.cache import Cache
 
 logger = logging.getLogger(__name__)
 
@@ -38,9 +38,9 @@ class GitHubService:
     GITHUB_API_BASE = "https://api.github.com"
     GITHUB_RAW_BASE = "https://raw.githubusercontent.com"
 
-    def __init__(self, settings: Settings, cache: Cache | None = None) -> None:
+    def __init__(self, settings: Settings, cache: Cache) -> None:
         self.settings = settings
-        self.cache = cache or get_cache()
+        self.cache = cache
         self._client: httpx.AsyncClient | None = None
 
     async def _get_client(self) -> httpx.AsyncClient:
@@ -330,25 +330,3 @@ class GitHubService:
         except yaml.YAMLError as exc:
             logger.warning("Failed to parse config YAML: %s", exc)
             return None
-
-
-# Global service instance
-_github_service: GitHubService | None = None
-
-
-def get_github_service() -> GitHubService:
-    """Get the global GitHub service instance."""
-    global _github_service
-    if _github_service is None:
-        from squishmark.config import get_settings
-
-        _github_service = GitHubService(get_settings())
-    return _github_service
-
-
-async def shutdown_github_service() -> None:
-    """Shutdown the global GitHub service."""
-    global _github_service
-    if _github_service:
-        await _github_service.close()
-        _github_service = None

--- a/src/squishmark/services/livereload.py
+++ b/src/squishmark/services/livereload.py
@@ -209,21 +209,3 @@ def _inject_script(body: bytes) -> bytes:
     if idx == -1:
         return body
     return body[:idx] + _LIVERELOAD_SCRIPT.encode() + body[idx:]
-
-
-# Global service instance
-_livereload_service: LiveReloadService | None = None
-
-
-def get_livereload_service() -> LiveReloadService:
-    """Get or create the global LiveReload service instance."""
-    global _livereload_service
-    if _livereload_service is None:
-        _livereload_service = LiveReloadService()
-    return _livereload_service
-
-
-def reset_livereload_service() -> None:
-    """Reset the global LiveReload service."""
-    global _livereload_service
-    _livereload_service = None

--- a/src/squishmark/services/markdown.py
+++ b/src/squishmark/services/markdown.py
@@ -13,7 +13,7 @@ from markdown.extensions.fenced_code import FencedCodeExtension
 from markdown.extensions.toc import TocExtension
 from pygments.formatters import HtmlFormatter
 
-from squishmark.models.content import Config, FrontMatter, Page, Post
+from squishmark.models.content import FrontMatter, Page, Post
 from squishmark.services.url_rewriter import rewrite_image_urls
 
 
@@ -298,22 +298,3 @@ class MarkdownService:
                 pass
 
         return None
-
-
-# Global service instance
-_markdown_service: MarkdownService | None = None
-
-
-def get_markdown_service(config: Config | None = None) -> MarkdownService:
-    """Get the global markdown service instance."""
-    global _markdown_service
-    if _markdown_service is None:
-        style = config.theme.pygments_style if config else "github-dark"
-        _markdown_service = MarkdownService(pygments_style=style)
-    return _markdown_service
-
-
-def reset_markdown_service() -> None:
-    """Reset the global markdown service. Useful for testing or config changes."""
-    global _markdown_service
-    _markdown_service = None

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pydantic import BaseModel
 
 from squishmark.models.content import Post
-from squishmark.services.cache import get_cache
+from squishmark.services.container import Services
 from squishmark.services.content import get_cached_posts
 
 MIN_QUERY_LENGTH = 2
@@ -177,7 +177,7 @@ def search_posts(query: str, posts: list[Post], limit: int = DEFAULT_LIMIT) -> l
     return query_index(query, build_search_index(posts), limit)
 
 
-async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
+async def get_search_index(services: Services, include_drafts: bool) -> list[IndexedPost]:
     """Return the cached index for the audience, building it on miss.
 
     Building is the expensive part (tokenizing every post body), so one miss
@@ -187,13 +187,13 @@ async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     every other derived blob. The parsed posts come from the shared cached
     content layer (get_cached_posts), so they are parsed at most once per TTL.
     """
-    cache = get_cache()
+    cache = services.cache
     key = SEARCH_INDEX_ALL_KEY if include_drafts else SEARCH_INDEX_PUBLISHED_KEY
     cached = await cache.get(key)
     if cached is not None:
         return cached
 
-    posts = await get_cached_posts(include_drafts=True)
+    posts = await get_cached_posts(services, include_drafts=True)
 
     all_index = build_search_index(posts)
     published_index = [indexed for indexed in all_index if not indexed.result.draft]
@@ -202,9 +202,9 @@ async def get_search_index(include_drafts: bool) -> list[IndexedPost]:
     return all_index if include_drafts else published_index
 
 
-async def warm_search_indexes() -> None:
+async def warm_search_indexes(services: Services) -> None:
     """Pre-build both audience index variants (used by the webhook warm).
 
     One call suffices: an index miss builds and caches both variants.
     """
-    await get_search_index(include_drafts=True)
+    await get_search_index(services, include_drafts=True)

--- a/src/squishmark/services/theme/__init__.py
+++ b/src/squishmark/services/theme/__init__.py
@@ -1,10 +1,5 @@
 """Theme engine for Jinja2 template rendering."""
 
-from squishmark.services.theme.engine import (
-    THEME_PYGMENTS_DEFAULTS,
-    ThemeEngine,
-    get_theme_engine,
-    reset_theme_engine,
-)
+from squishmark.services.theme.engine import THEME_PYGMENTS_DEFAULTS, ThemeEngine
 
-__all__ = ["THEME_PYGMENTS_DEFAULTS", "ThemeEngine", "get_theme_engine", "reset_theme_engine"]
+__all__ = ["THEME_PYGMENTS_DEFAULTS", "ThemeEngine"]

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -59,19 +59,19 @@ class ThemeEngine:
         # Favicon detector for content repository
         self.favicon_detector = FaviconDetector(self.github_service)
 
-    async def load_custom_templates(self) -> int:
+    async def load_custom_templates(self, use_cache: bool = True) -> int:
         """
         Pre-load custom templates from the content repository.
 
         Returns:
             Number of custom templates loaded
         """
-        custom_templates = await self.github_service.list_directory("theme")
+        custom_templates = await self.github_service.list_directory("theme", use_cache=use_cache)
         count = 0
 
         for path in custom_templates:
             if path.endswith(".html"):
-                file = await self.github_service.get_file(path)
+                file = await self.github_service.get_file(path, use_cache=use_cache)
                 if file:
                     # Extract template name from path (e.g., "theme/post.html" -> "post.html")
                     template_name = path.split("/")[-1]
@@ -314,4 +314,6 @@ class ThemeEngine:
         # cache must be dropped too or edited templates keep serving stale.
         if self.env.cache is not None:
             self.env.cache.clear()
-        await self.load_custom_templates()
+        # Bypass the content cache so reload does not depend on callers
+        # having cleared it first.
+        await self.load_custom_templates(use_cache=False)

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -1,5 +1,6 @@
 """Theme engine for Jinja2 template rendering."""
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -10,6 +11,8 @@ from squishmark.services.content import get_cached_pages
 from squishmark.services.theme.favicon import FaviconDetector
 from squishmark.services.theme.filters import register_filters
 from squishmark.services.theme.loader import AsyncHybridLoader, ThemedEnvironment
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from squishmark.services.container import Services
@@ -146,6 +149,7 @@ class ThemeEngine:
         """
         # Resolve theme name (override or config default)
         theme_name = theme_override or config.theme.name
+        logger.debug("Rendering %s with theme %s", template_name, theme_name)
 
         # Theme-prefixed name so lookup is stateless (loader resolves the
         # custom / theme / default fallback chain from the prefix).

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -12,6 +12,7 @@ from squishmark.services.theme.filters import register_filters
 from squishmark.services.theme.loader import AsyncHybridLoader, ThemedEnvironment
 
 if TYPE_CHECKING:
+    from squishmark.services.container import Services
     from squishmark.services.github import GitHubService
 
 # Default pygments style shipped with each bundled theme.
@@ -31,8 +32,13 @@ class ThemeEngine:
         self,
         github_service: "GitHubService",
         themes_path: Path | None = None,
+        services: "Services | None" = None,
     ) -> None:
         self.github_service = github_service
+        # Needed by get_nav_pages to reach the shared cached content layer.
+        # Set at construction in production; None in unit tests that patch
+        # get_cached_pages directly.
+        self.services = services
 
         # Default to the bundled themes directory
         if themes_path is None:
@@ -90,7 +96,8 @@ class ThemeEngine:
         # per TTL instead of on every render. The visible variant already
         # excludes hidden pages; keep the explicit public filter (unlisted pages
         # stay out of the navbar).
-        cached_pages = await get_cached_pages(include_hidden=False)
+        assert self.services is not None, "ThemeEngine.services must be set before rendering"
+        cached_pages = await get_cached_pages(self.services, include_hidden=False)
         pages = [p for p in cached_pages if p.visibility == "public"]
 
         # Sort: pages with nav_order first (ascending), then alphabetical by title
@@ -300,27 +307,13 @@ class ThemeEngine:
         template = self.env.get_template(f"{theme_name}/{template_name}")
         return template.render(**context)
 
+    async def reload(self) -> None:
+        """Drop cached custom templates and favicon, then reload from the repo.
 
-# Global theme engine instance
-_theme_engine: ThemeEngine | None = None
-
-
-async def get_theme_engine(github_service: "GitHubService | None" = None) -> ThemeEngine:
-    """Get or create the global theme engine instance."""
-    global _theme_engine
-    if _theme_engine is None:
-        if github_service is None:
-            from squishmark.services.github import get_github_service
-
-            github_service = get_github_service()
-        _theme_engine = ThemeEngine(github_service)
-        await _theme_engine.load_custom_templates()
-    return _theme_engine
-
-
-def reset_theme_engine() -> None:
-    """Reset the global theme engine. Useful for testing or cache refresh."""
-    global _theme_engine
-    if _theme_engine:
-        _theme_engine.favicon_detector.clear_cache()
-    _theme_engine = None
+        Called after a content push (webhook / admin refresh). Clearing the
+        loader cache first means a template removed from the content repo stops
+        being served, matching the old rebuild-from-scratch behavior.
+        """
+        self.favicon_detector.clear_cache()
+        self.loader.clear_cache()
+        await self.load_custom_templates()

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -13,7 +13,6 @@ from squishmark.services.theme.loader import AsyncHybridLoader, ThemedEnvironmen
 
 if TYPE_CHECKING:
     from squishmark.services.container import Services
-    from squishmark.services.github import GitHubService
 
 # Default pygments style shipped with each bundled theme.
 # When the user's configured pygments_style matches, the theme's hand-tuned
@@ -30,15 +29,11 @@ class ThemeEngine:
 
     def __init__(
         self,
-        github_service: "GitHubService",
+        services: "Services",
         themes_path: Path | None = None,
-        services: "Services | None" = None,
     ) -> None:
-        self.github_service = github_service
-        # Needed by get_nav_pages to reach the shared cached content layer.
-        # Set at construction in production; None in unit tests that patch
-        # get_cached_pages directly.
         self.services = services
+        self.github_service = services.github
 
         # Default to the bundled themes directory
         if themes_path is None:
@@ -62,7 +57,7 @@ class ThemeEngine:
         register_filters(self.env)
 
         # Favicon detector for content repository
-        self.favicon_detector = FaviconDetector(github_service)
+        self.favicon_detector = FaviconDetector(self.github_service)
 
     async def load_custom_templates(self) -> int:
         """
@@ -96,7 +91,6 @@ class ThemeEngine:
         # per TTL instead of on every render. The visible variant already
         # excludes hidden pages; keep the explicit public filter (unlisted pages
         # stay out of the navbar).
-        assert self.services is not None, "ThemeEngine.services must be set before rendering"
         cached_pages = await get_cached_pages(self.services, include_hidden=False)
         pages = [p for p in cached_pages if p.visibility == "public"]
 
@@ -316,4 +310,8 @@ class ThemeEngine:
         """
         self.favicon_detector.clear_cache()
         self.loader.clear_cache()
+        # Custom templates report uptodate=True, so Jinja's compiled-template
+        # cache must be dropped too or edited templates keep serving stale.
+        if self.env.cache is not None:
+            self.env.cache.clear()
         await self.load_custom_templates()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,10 @@ custom HTML 404 handler) via ``TestClient`` used as a context manager. The
 GitHub content layer is replaced with an in-memory :class:`FakeGitHubService`
 so no network access is required.
 
-The autouse :func:`_reset_environment` fixture is the linchpin: it points every
-process-global singleton at per-test state and tears it all down afterwards so
-the pre-existing (non-integration) test modules stay green.
+The autouse :func:`_reset_environment` fixture is the linchpin: it clears the
+settings cache and, for the HTTP integration modules, injects a
+:class:`FakeGitHubService` into the lifespan-built service container by patching
+the container's ``create_github_service`` factory.
 """
 
 from collections.abc import Callable, Iterator
@@ -16,22 +17,20 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
-import squishmark.services.github as github_module
+import squishmark.services.container as container_module
 from squishmark.config import get_settings
 from squishmark.main import create_app
-from squishmark.services.cache import reset_cache
 from squishmark.services.github import GitHubBinaryFile, GitHubFile
-from squishmark.services.markdown import reset_markdown_service
-from squishmark.services.theme import reset_theme_engine
 
 
 class FakeGitHubService:
     """Dict-backed stand-in for :class:`~squishmark.services.github.GitHubService`.
 
-    Matches the real public coroutine signatures so it can be dropped in as the
-    module-global ``_github_service``. ``list_directory`` derives a directory's
-    children from the keys of ``files`` (and ``binary_files``) by prefix match,
-    mirroring how the real service lists a GitHub/local directory.
+    Matches the real public coroutine signatures so it can be dropped into the
+    service container in place of the real GitHub service. ``list_directory``
+    derives a directory's children from the keys of ``files`` (and
+    ``binary_files``) by prefix match, mirroring how the real service lists a
+    GitHub/local directory.
     """
 
     def __init__(
@@ -191,19 +190,17 @@ def _reset_environment(
     tmp_path: Any,
     make_content: Callable[..., FakeGitHubService],
 ) -> Iterator[FakeGitHubService | None]:
-    """Per-test isolation of every process-global singleton.
+    """Per-test isolation of settings and (for integration modules) the fake.
 
-    For the HTTP integration modules this also pins the environment the real
+    For the HTTP integration modules this pins the environment the real
     ``create_app()`` reads (file-based SQLite — ``:memory:`` loses tables across
     the separate connections SQLAlchemy's async pool opens — plus secret/admin/
-    webhook config) and installs a default fake GitHub service as the module
-    global. Tests can swap in their own via ``github_module._github_service = ...``
-    before constructing a client.
+    webhook config) and injects a default fake GitHub service into the
+    lifespan-built container by patching ``create_github_service``.
 
     The env-pinning is scoped to this PR's integration modules so it never
     pollutes ``os.environ`` for the pre-existing suites — several of which build
-    a bare ``Settings()`` and assert on environment-derived defaults. The
-    singleton resets below run for *every* test and are side-effect free.
+    a bare ``Settings()`` and assert on environment-derived defaults.
     """
     is_integration = request.module.__name__.rsplit(".", 1)[-1] in _INTEGRATION_MODULES
 
@@ -218,22 +215,15 @@ def _reset_environment(
         monkeypatch.setenv("DEV_SKIP_AUTH", "false")
 
     get_settings.cache_clear()
-    reset_cache()
-    reset_markdown_service()
-    reset_theme_engine()
 
     fake: FakeGitHubService | None = None
     if is_integration:
         fake = make_content()
-        github_module._github_service = fake
+        monkeypatch.setattr(container_module, "create_github_service", lambda settings, cache: fake)
 
     yield fake
 
-    github_module._github_service = None
     get_settings.cache_clear()
-    reset_cache()
-    reset_markdown_service()
-    reset_theme_engine()
 
 
 # --- Clients ---------------------------------------------------------------

--- a/tests/test_admin_notes.py
+++ b/tests/test_admin_notes.py
@@ -58,6 +58,8 @@ async def test_create_note_json_returns_json_response():
             request=_request(json_body={"path": "/posts/x", "text": "JSON note", "is_public": True}),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
         )
 
     assert not isinstance(result, HTMLResponse)
@@ -90,13 +92,15 @@ async def test_create_note_htmx_form_returns_html_partial():
             ),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
         )
 
     assert isinstance(result, HTMLResponse)
     assert result.status_code == 201
     assert b'id="note-7"' in result.body
     mock_render.assert_awaited_once()
-    assert mock_render.call_args.args == ("admin/_note_item.html",)
+    assert mock_render.call_args.args[2] == "admin/_note_item.html"
 
 
 @pytest.mark.asyncio
@@ -119,6 +123,8 @@ async def test_create_note_htmx_checkbox_omitted_persists_false():
             ),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
         )
 
     mock_service.create.assert_called_once()
@@ -149,6 +155,8 @@ async def test_update_note_htmx_toggle_off_persists_false():
             ),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
             note_id=1,
         )
 
@@ -169,6 +177,8 @@ async def test_update_note_not_found_raises_404():
                 request=_request(json_body={"text": "x"}),
                 admin="test-admin",
                 session=AsyncMock(),
+                services=MagicMock(),
+                theme_engine=MagicMock(),
                 note_id=999,
             )
 
@@ -251,12 +261,14 @@ async def test_edit_note_form_renders_partial():
         result = await edit_note_form(
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
             note_id=3,
         )
 
     assert isinstance(result, HTMLResponse)
     assert b"note-edit-form" in result.body
-    assert mock_render.call_args.args == ("admin/_note_edit_form.html",)
+    assert mock_render.call_args.args[2] == "admin/_note_edit_form.html"
 
 
 @pytest.mark.asyncio
@@ -277,12 +289,14 @@ async def test_view_note_renders_item_partial():
         result = await view_note(
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
             note_id=3,
         )
 
     assert isinstance(result, HTMLResponse)
     assert b'id="note-3"' in result.body
-    assert mock_render.call_args.args == ("admin/_note_item.html",)
+    assert mock_render.call_args.args[2] == "admin/_note_item.html"
 
 
 @pytest.mark.asyncio
@@ -295,7 +309,13 @@ async def test_edit_form_not_found_raises_404():
 
     with patch("squishmark.routers.admin.NotesService", return_value=mock_service):
         with pytest.raises(HTTPException) as exc_info:
-            await edit_note_form(admin="test-admin", session=AsyncMock(), note_id=999)
+            await edit_note_form(
+                admin="test-admin",
+                session=AsyncMock(),
+                services=MagicMock(),
+                theme_engine=MagicMock(),
+                note_id=999,
+            )
 
     assert exc_info.value.status_code == 404
 
@@ -408,7 +428,13 @@ async def test_create_note_invalid_json_returns_422():
     request.json = AsyncMock(side_effect=json.JSONDecodeError("Expecting value", "x", 0))
 
     with pytest.raises(HTTPException) as exc_info:
-        await create_note(request=request, admin="test-admin", session=AsyncMock())
+        await create_note(
+            request=request,
+            admin="test-admin",
+            session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
+        )
 
     assert exc_info.value.status_code == 422
     assert "Invalid JSON" in str(exc_info.value.detail)
@@ -424,6 +450,8 @@ async def test_create_note_json_missing_required_returns_422():
             request=_request(json_body={"path": "/x"}),  # missing 'text'
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
         )
 
     assert exc_info.value.status_code == 422
@@ -443,6 +471,8 @@ async def test_create_note_htmx_form_missing_path_returns_422():
             ),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
         )
 
     assert exc_info.value.status_code == 422
@@ -468,6 +498,8 @@ async def test_update_note_htmx_form_missing_text_leaves_text_unchanged():
             ),
             admin="test-admin",
             session=AsyncMock(),
+            services=MagicMock(),
+            theme_engine=MagicMock(),
             note_id=1,
         )
 

--- a/tests/test_analytics_filtering.py
+++ b/tests/test_analytics_filtering.py
@@ -56,13 +56,12 @@ async def _build_app():
         "theme": {"name": "default", "pygments_style": "github-dark"},
         "site": {"title": "Test"},
     }
+    # Theme engine loads custom templates during the lifespan.
+    mock_github.list_directory.return_value = []
     stack = [
-        patch("squishmark.main.get_github_service", return_value=mock_github),
-        patch("squishmark.main.get_theme_engine", new_callable=AsyncMock),
-        patch("squishmark.models.db.init_db", new_callable=AsyncMock),
-        patch("squishmark.models.db.close_db", new_callable=AsyncMock),
-        patch("squishmark.main.shutdown_github_service", new_callable=AsyncMock),
-        patch("squishmark.main.reset_theme_engine"),
+        patch("squishmark.services.container.create_github_service", return_value=mock_github),
+        patch("squishmark.main.init_db", new_callable=AsyncMock),
+        patch("squishmark.main.close_db", new_callable=AsyncMock),
     ]
     return stack
 
@@ -81,9 +80,6 @@ async def _assert_track_called(headers: dict, path: str, expected: bool, add_htm
         stack[0],
         stack[1],
         stack[2],
-        stack[3],
-        stack[4],
-        stack[5],
         patch("squishmark.services.analytics_middleware.track_page_view", new=tracker),
     ):
         from squishmark.main import create_app
@@ -95,11 +91,14 @@ async def _assert_track_called(headers: dict, path: str, expected: bool, add_htm
             async def _test_html():
                 return HTMLResponse("<html><body>test</body></html>")
 
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            await client.get(path, headers=headers)
-        # Fire-and-forget task may not have completed yet; yield a tick.
-        await asyncio.sleep(0)
+        # ASGITransport does not emit lifespan events, so run the lifespan
+        # explicitly to build the service container on app.state.
+        async with app.router.lifespan_context(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                await client.get(path, headers=headers)
+            # Fire-and-forget task may not have completed yet; yield a tick.
+            await asyncio.sleep(0)
         assert tracker.called is expected, (
             f"expected track_page_view.called={expected} for path={path!r} "
             f"ua={headers.get('user-agent')!r}; got called={tracker.called}"

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -6,7 +6,8 @@ from typing import Any
 import pytest
 
 from squishmark.models.content import Post, SiteConfig
-from squishmark.services.cache import get_cache
+from squishmark.services.cache import Cache
+from squishmark.services.container import Services
 from squishmark.services.content import (
     PAGES_ALL_KEY,
     PAGES_VISIBLE_KEY,
@@ -104,70 +105,70 @@ class _CountingGitHub:
 
 
 @pytest.fixture
-def fake_github(monkeypatch: pytest.MonkeyPatch) -> _CountingGitHub:
-    """Install a counting fake as the service the cached layer resolves.
-
-    DEBUG is pinned false so the cache TTL is non-zero (a zero TTL expires
-    entries immediately, which would defeat the reuse assertions).
-    """
-    from squishmark.config import get_settings
-    from squishmark.services.cache import reset_cache
-
-    monkeypatch.setenv("DEBUG", "false")
-    get_settings.cache_clear()
-    reset_cache()
-
+def fake_github() -> _CountingGitHub:
+    """A counting fake with a fixed set of posts and pages."""
     files = {
         "posts/2026-01-02-published.md": _post_md("Published"),
         "posts/2026-01-03-secret.md": _post_md("Secret", draft=True),
         "pages/about.md": _page_md("About"),
         "pages/hidden.md": _page_md("Hidden", visibility="hidden"),
     }
-    fake = _CountingGitHub(files)
-    monkeypatch.setattr("squishmark.services.content.get_github_service", lambda: fake)
-    return fake
+    return _CountingGitHub(files)
+
+
+@pytest.fixture
+def services(fake_github: _CountingGitHub) -> Services:
+    """A service container wrapping the counting fake and a real cache.
+
+    A non-zero TTL keeps entries alive across calls so the reuse assertions
+    hold (a zero TTL expires entries immediately).
+    """
+    from squishmark.config import get_settings
+
+    cache = Cache(ttl_seconds=get_settings().cache_ttl_seconds)
+    return Services(settings=get_settings(), cache=cache, github=fake_github)
 
 
 class TestGetCachedPosts:
     """Draft gating, audience-variant caching, and invalidation for posts."""
 
     @pytest.mark.asyncio
-    async def test_published_variant_excludes_drafts(self, fake_github: _CountingGitHub) -> None:
-        published = await get_cached_posts(include_drafts=False)
+    async def test_published_variant_excludes_drafts(self, services: Services) -> None:
+        published = await get_cached_posts(services, include_drafts=False)
         assert [p.slug for p in published] == ["published"]
 
     @pytest.mark.asyncio
-    async def test_all_variant_includes_drafts(self, fake_github: _CountingGitHub) -> None:
-        all_posts = await get_cached_posts(include_drafts=True)
+    async def test_all_variant_includes_drafts(self, services: Services) -> None:
+        all_posts = await get_cached_posts(services, include_drafts=True)
         assert {p.slug for p in all_posts} == {"published", "secret"}
 
     @pytest.mark.asyncio
-    async def test_one_miss_caches_both_variants(self, fake_github: _CountingGitHub) -> None:
+    async def test_one_miss_caches_both_variants(self, services: Services, fake_github: _CountingGitHub) -> None:
         """A single published miss must also populate the admin variant, so the
         admin request that follows never re-parses (and never leaks the other
         way around)."""
-        await get_cached_posts(include_drafts=False)
+        await get_cached_posts(services, include_drafts=False)
         after_first = fake_github.get_file_calls
         assert after_first > 0
 
         # The drafts-included variant is served from the same miss: no re-fetch.
-        all_posts = await get_cached_posts(include_drafts=True)
+        all_posts = await get_cached_posts(services, include_drafts=True)
         assert fake_github.get_file_calls == after_first
         assert {p.slug for p in all_posts} == {"published", "secret"}
 
     @pytest.mark.asyncio
-    async def test_repeat_call_does_not_refetch(self, fake_github: _CountingGitHub) -> None:
-        await get_cached_posts(include_drafts=False)
+    async def test_repeat_call_does_not_refetch(self, services: Services, fake_github: _CountingGitHub) -> None:
+        await get_cached_posts(services, include_drafts=False)
         after_first = fake_github.get_file_calls
-        await get_cached_posts(include_drafts=False)
+        await get_cached_posts(services, include_drafts=False)
         assert fake_github.get_file_calls == after_first
 
     @pytest.mark.asyncio
-    async def test_clear_invalidates(self, fake_github: _CountingGitHub) -> None:
-        await get_cached_posts(include_drafts=False)
+    async def test_clear_invalidates(self, services: Services, fake_github: _CountingGitHub) -> None:
+        await get_cached_posts(services, include_drafts=False)
         after_first = fake_github.get_file_calls
-        await get_cache().clear()
-        await get_cached_posts(include_drafts=False)
+        await services.cache.clear()
+        await get_cached_posts(services, include_drafts=False)
         assert fake_github.get_file_calls > after_first
 
 
@@ -175,29 +176,29 @@ class TestGetCachedPages:
     """Hidden gating, audience-variant caching, and invalidation for pages."""
 
     @pytest.mark.asyncio
-    async def test_visible_variant_excludes_hidden(self, fake_github: _CountingGitHub) -> None:
-        visible = await get_cached_pages(include_hidden=False)
+    async def test_visible_variant_excludes_hidden(self, services: Services) -> None:
+        visible = await get_cached_pages(services, include_hidden=False)
         assert [p.slug for p in visible] == ["about"]
 
     @pytest.mark.asyncio
-    async def test_all_variant_includes_hidden(self, fake_github: _CountingGitHub) -> None:
-        all_pages = await get_cached_pages(include_hidden=True)
+    async def test_all_variant_includes_hidden(self, services: Services) -> None:
+        all_pages = await get_cached_pages(services, include_hidden=True)
         assert {p.slug for p in all_pages} == {"about", "hidden"}
 
     @pytest.mark.asyncio
-    async def test_one_miss_caches_both_variants(self, fake_github: _CountingGitHub) -> None:
-        await get_cached_pages(include_hidden=False)
+    async def test_one_miss_caches_both_variants(self, services: Services, fake_github: _CountingGitHub) -> None:
+        await get_cached_pages(services, include_hidden=False)
         after_first = fake_github.get_file_calls
-        all_pages = await get_cached_pages(include_hidden=True)
+        all_pages = await get_cached_pages(services, include_hidden=True)
         assert fake_github.get_file_calls == after_first
         assert {p.slug for p in all_pages} == {"about", "hidden"}
 
 
 class TestWarmContentCaches:
     @pytest.mark.asyncio
-    async def test_warm_populates_all_variants(self, fake_github: _CountingGitHub) -> None:
-        await warm_content_caches()
-        cache = get_cache()
+    async def test_warm_populates_all_variants(self, services: Services) -> None:
+        await warm_content_caches(services)
+        cache = services.cache
         assert await cache.get(POSTS_ALL_KEY) is not None
         assert await cache.get(POSTS_PUBLISHED_KEY) is not None
         assert await cache.get(PAGES_ALL_KEY) is not None

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,13 +1,14 @@
 """Tests for Atom feed route."""
 
 import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from xml.etree.ElementTree import fromstring
 
 import pytest
 
 from squishmark.models.content import Config, Post
 from squishmark.routers.feed import _build_atom_feed, _rfc3339
+from squishmark.services.container import Services
 
 ATOM_NS = "http://www.w3.org/2005/Atom"
 
@@ -15,6 +16,11 @@ ATOM_NS = "http://www.w3.org/2005/Atom"
 def _ns(tag: str) -> str:
     """Prefix a tag with the Atom namespace."""
     return f"{{{ATOM_NS}}}{tag}"
+
+
+def _services(github: AsyncMock, cache: AsyncMock) -> Services:
+    """Build a service container wrapping the given github and cache mocks."""
+    return Services(settings=MagicMock(), cache=cache, github=github)
 
 
 @pytest.fixture
@@ -148,18 +154,12 @@ class TestAtomFeedEndpoint:
             MagicMock(content="---\ntitle: Draft\ndate: 2026-01-02\ndraft: true\n---\nDraft content here."),
         ]
 
-        with (
-            patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.feed import atom_feed
+        from squishmark.routers.feed import atom_feed
 
-            response = await atom_feed()
+        response = await atom_feed(_services(mock_github, mock_cache))
 
         root = fromstring(response.body)
         entries = root.findall(_ns("entry"))
@@ -179,18 +179,12 @@ class TestAtomFeedEndpoint:
             MagicMock(content=f"---\ntitle: Post {i}\ndate: 2026-01-{i:02d}\n---\nContent {i}") for i in range(1, 26)
         ]
 
-        with (
-            patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.feed import atom_feed
+        from squishmark.routers.feed import atom_feed
 
-            response = await atom_feed()
+        response = await atom_feed(_services(mock_github, mock_cache))
 
         root = fromstring(response.body)
         entries = root.findall(_ns("entry"))
@@ -203,18 +197,12 @@ class TestAtomFeedEndpoint:
         mock_github.get_config.return_value = {"site": {"title": "Test"}}
         mock_github.list_directory.return_value = []
 
-        with (
-            patch("squishmark.routers.feed.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.feed.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.feed import atom_feed
+        from squishmark.routers.feed import atom_feed
 
-            response = await atom_feed()
+        response = await atom_feed(_services(mock_github, mock_cache))
 
         assert "application/atom+xml" in response.media_type
 
@@ -223,13 +211,11 @@ class TestAtomFeedEndpoint:
         """Cached XML should be returned without rebuilding."""
         cached_xml = b'<?xml version="1.0"?><feed>cached</feed>'
 
-        with patch("squishmark.routers.feed.get_cache") as mock_cache_fn:
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = cached_xml
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = cached_xml
 
-            from squishmark.routers.feed import atom_feed
+        from squishmark.routers.feed import atom_feed
 
-            response = await atom_feed()
+        response = await atom_feed(_services(AsyncMock(), mock_cache))
 
         assert response.body == cached_xml

--- a/tests/test_nav_pages.py
+++ b/tests/test_nav_pages.py
@@ -135,7 +135,7 @@ class TestGetNavPages:
         from squishmark.services.theme.engine import ThemeEngine
 
         visible = [self._page("About", "public"), self._page("Draft", "unlisted")]
-        engine = ThemeEngine(AsyncMock(), services=MagicMock())
+        engine = ThemeEngine(MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -154,7 +154,7 @@ class TestGetNavPages:
             self._page("Projects"),
             self._page("Blog"),
         ]
-        engine = ThemeEngine(AsyncMock(), services=MagicMock())
+        engine = ThemeEngine(MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -169,7 +169,7 @@ class TestGetNavPages:
         from squishmark.services.theme.engine import ThemeEngine
 
         visible = [self._page("A"), self._page("B"), self._page("C")]
-        engine = ThemeEngine(AsyncMock(), services=MagicMock())
+        engine = ThemeEngine(MagicMock())
         config = Config(theme=ThemeConfig(nav_max_pages=2))
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -181,7 +181,7 @@ class TestGetNavPages:
         """Should return empty list when no pages exist."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        engine = ThemeEngine(AsyncMock(), services=MagicMock())
+        engine = ThemeEngine(MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=[])):
             pages = await engine.get_nav_pages(config)

--- a/tests/test_nav_pages.py
+++ b/tests/test_nav_pages.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from squishmark.models.content import Config, FrontMatter, Page, ThemeConfig
+from squishmark.services.container import Services
 from squishmark.services.markdown import MarkdownService
 
 
@@ -78,19 +79,15 @@ class TestHiddenPage404:
         mock_request = MagicMock()
         hidden_content = "---\ntitle: Secret\nvisibility: hidden\n---\nContent"
 
-        with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
-            patch("squishmark.routers.pages.get_theme_engine"),
-            patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
-        ):
+        with patch("squishmark.routers.pages.NotesService") as mock_notes_cls:
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=hidden_content)
             mock_notes_cls.return_value = AsyncMock()
+            services = Services(settings=MagicMock(), cache=AsyncMock(), github=mock_github)
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_page(mock_request, "secret", db=AsyncMock())
+                await get_page(mock_request, services, AsyncMock(), "secret", db=AsyncMock())
 
             assert exc_info.value.status_code == 404
 
@@ -102,22 +99,20 @@ class TestHiddenPage404:
         unlisted_content = "---\ntitle: Unlisted\nvisibility: unlisted\n---\nContent"
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
+            patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=unlisted_content)
             mock_notes_cls.return_value = AsyncMock()
 
             mock_engine = AsyncMock()
-            mock_get_engine.return_value = mock_engine
             mock_engine.render_page.return_value = "<html>Unlisted</html>"
 
+            services = Services(settings=MagicMock(), cache=AsyncMock(), github=mock_github)
             mock_request = MagicMock()
-            response = await get_page(mock_request, "unlisted", db=AsyncMock())
+            response = await get_page(mock_request, services, mock_engine, "unlisted", db=AsyncMock())
 
             assert response.status_code == 200
 
@@ -140,7 +135,7 @@ class TestGetNavPages:
         from squishmark.services.theme.engine import ThemeEngine
 
         visible = [self._page("About", "public"), self._page("Draft", "unlisted")]
-        engine = ThemeEngine(AsyncMock())
+        engine = ThemeEngine(AsyncMock(), services=MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -159,7 +154,7 @@ class TestGetNavPages:
             self._page("Projects"),
             self._page("Blog"),
         ]
-        engine = ThemeEngine(AsyncMock())
+        engine = ThemeEngine(AsyncMock(), services=MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -174,7 +169,7 @@ class TestGetNavPages:
         from squishmark.services.theme.engine import ThemeEngine
 
         visible = [self._page("A"), self._page("B"), self._page("C")]
-        engine = ThemeEngine(AsyncMock())
+        engine = ThemeEngine(AsyncMock(), services=MagicMock())
         config = Config(theme=ThemeConfig(nav_max_pages=2))
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=visible)):
             pages = await engine.get_nav_pages(config)
@@ -186,7 +181,7 @@ class TestGetNavPages:
         """Should return empty list when no pages exist."""
         from squishmark.services.theme.engine import ThemeEngine
 
-        engine = ThemeEngine(AsyncMock())
+        engine = ThemeEngine(AsyncMock(), services=MagicMock())
         config = Config()
         with patch("squishmark.services.theme.engine.get_cached_pages", AsyncMock(return_value=[])):
             pages = await engine.get_nav_pages(config)

--- a/tests/test_notes_rendering.py
+++ b/tests/test_notes_rendering.py
@@ -4,6 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from squishmark.services.cache import Cache
+from squishmark.services.container import Services
+
 POST_CONTENT = "---\ntitle: Test Post\ndate: 2026-01-01\n---\nContent"
 PAGE_CONTENT = "---\ntitle: About\n---\nContent"
 
@@ -22,6 +25,15 @@ def _anonymous_request():
     return request
 
 
+def _services(mock_github: AsyncMock) -> Services:
+    """Build a service container wrapping the given github mock.
+
+    A real cache (not an AsyncMock, whose ``get`` returns a truthy mock and
+    would read as a false cache hit) so the cached content layer parses.
+    """
+    return Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=mock_github)
+
+
 class TestPostNotesRendering:
     """Tests for notes being fetched and passed to templates on post pages."""
 
@@ -34,21 +46,17 @@ class TestPostNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.posts.get_github_service") as mock_get_github,
-            patch("squishmark.services.content.get_github_service", mock_get_github),
-            patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.list_directory.return_value = ["posts/2026-01-01-my-post.md"]
             mock_github.get_file.return_value = MagicMock(content=POST_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_anonymous_request(), "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=False)
 
@@ -61,21 +69,17 @@ class TestPostNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.posts.get_github_service") as mock_get_github,
-            patch("squishmark.services.content.get_github_service", mock_get_github),
-            patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=True),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.list_directory.return_value = ["posts/2026-01-01-my-post.md"]
             mock_github.get_file.return_value = MagicMock(content=POST_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_admin_request(), "my-post", db=AsyncMock())
+            await get_post(_admin_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=True)
 
@@ -88,21 +92,17 @@ class TestPostNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.posts.get_github_service") as mock_get_github,
-            patch("squishmark.services.content.get_github_service", mock_get_github),
-            patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.list_directory.return_value = ["posts/2026-01-01-my-post.md"]
             mock_github.get_file.return_value = MagicMock(content=POST_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_anonymous_request(), "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=False)
 
@@ -116,27 +116,21 @@ class TestPostNotesRendering:
         mock_notes.get_for_path.return_value = fake_notes
 
         with (
-            patch("squishmark.routers.posts.get_github_service") as mock_get_github,
-            patch("squishmark.services.content.get_github_service", mock_get_github),
-            patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.list_directory.return_value = ["posts/2026-01-01-my-post.md"]
             mock_github.get_file.return_value = MagicMock(content=POST_CONTENT)
             mock_notes_cls.return_value = mock_notes
+            engine = AsyncMock()
+            engine.render_post.return_value = "<html></html>"
 
-            mock_engine = AsyncMock()
-            mock_get_engine.return_value = mock_engine
-            mock_engine.render_post.return_value = "<html></html>"
-
-            await get_post(_anonymous_request(), "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
 
             # Verify notes were passed as the third positional arg to render_post
-            call_args = mock_engine.render_post.call_args
+            call_args = engine.render_post.call_args
             assert call_args[0][2] == fake_notes
 
     @pytest.mark.asyncio
@@ -148,24 +142,20 @@ class TestPostNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.posts.get_github_service") as mock_get_github,
-            patch("squishmark.services.content.get_github_service", mock_get_github),
-            patch("squishmark.routers.posts.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.posts.NotesService") as mock_notes_cls,
             patch("squishmark.routers.posts.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.list_directory.return_value = ["posts/2026-01-01-my-post.md"]
             mock_github.get_file.return_value = MagicMock(content=POST_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            response = await get_post(_anonymous_request(), "my-post", db=AsyncMock())
+            response = await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
 
             assert response.status_code == 200
-            call_args = mock_get_engine.return_value.render_post.call_args
+            call_args = engine.render_post.call_args
             assert call_args[0][2] == []
 
 
@@ -181,20 +171,17 @@ class TestPageNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
             patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=PAGE_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_anonymous_request(), "about", db=AsyncMock())
+            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=False)
 
@@ -207,20 +194,17 @@ class TestPageNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
             patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=True),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=PAGE_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_admin_request(), "about", db=AsyncMock())
+            await get_page(_admin_request(), _services(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=True)
 
@@ -233,20 +217,17 @@ class TestPageNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
             patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=PAGE_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_anonymous_request(), "about", db=AsyncMock())
+            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=False)
 
@@ -260,25 +241,20 @@ class TestPageNotesRendering:
         mock_notes.get_for_path.return_value = fake_notes
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
             patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=PAGE_CONTENT)
             mock_notes_cls.return_value = mock_notes
+            engine = AsyncMock()
+            engine.render_page.return_value = "<html></html>"
 
-            mock_engine = AsyncMock()
-            mock_get_engine.return_value = mock_engine
-            mock_engine.render_page.return_value = "<html></html>"
+            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
 
-            await get_page(_anonymous_request(), "about", db=AsyncMock())
-
-            call_args = mock_engine.render_page.call_args
+            call_args = engine.render_page.call_args
             assert call_args[0][2] == fake_notes
 
     @pytest.mark.asyncio
@@ -290,21 +266,18 @@ class TestPageNotesRendering:
         mock_notes.get_for_path.return_value = []
 
         with (
-            patch("squishmark.routers.pages.get_github_service") as mock_get_github,
             patch("squishmark.routers.pages.get_cached_posts", AsyncMock(return_value=[])),
-            patch("squishmark.routers.pages.get_theme_engine") as mock_get_engine,
             patch("squishmark.routers.pages.NotesService") as mock_notes_cls,
             patch("squishmark.routers.pages.is_admin", return_value=False),
         ):
             mock_github = AsyncMock()
-            mock_get_github.return_value = mock_github
             mock_github.get_config.return_value = None
             mock_github.get_file.return_value = MagicMock(content=PAGE_CONTENT)
             mock_notes_cls.return_value = mock_notes
-            mock_get_engine.return_value = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
+            engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            response = await get_page(_anonymous_request(), "about", db=AsyncMock())
+            response = await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
 
             assert response.status_code == 200
-            call_args = mock_get_engine.return_value.render_page.call_args
+            call_args = engine.render_page.call_args
             assert call_args[0][2] == []

--- a/tests/test_pygments_css.py
+++ b/tests/test_pygments_css.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from squishmark.models.content import Config, ThemeConfig
-from squishmark.services.markdown import MarkdownService, reset_markdown_service
+from squishmark.services.markdown import MarkdownService
 from squishmark.services.theme.engine import THEME_PYGMENTS_DEFAULTS, ThemeEngine
 
 # ---------------------------------------------------------------------------
@@ -81,32 +81,29 @@ def test_get_pygments_css_custom_style():
 @pytest.mark.asyncio
 async def test_pygments_css_route():
     """Test the /pygments.css endpoint returns valid CSS."""
-    reset_markdown_service()
-
     mock_github = AsyncMock()
     mock_github.get_config.return_value = {
         "theme": {"name": "default", "pygments_style": "dracula"},
     }
+    # Theme engine loads custom templates during the lifespan.
+    mock_github.list_directory.return_value = []
 
     with (
-        patch("squishmark.routers.assets.get_github_service", return_value=mock_github),
-        patch("squishmark.main.get_theme_engine", new_callable=AsyncMock),
-        patch("squishmark.models.db.init_db", new_callable=AsyncMock),
-        patch("squishmark.models.db.close_db", new_callable=AsyncMock),
-        patch("squishmark.main.shutdown_github_service", new_callable=AsyncMock),
-        patch("squishmark.main.reset_theme_engine"),
+        patch("squishmark.services.container.create_github_service", return_value=mock_github),
+        patch("squishmark.main.init_db", new_callable=AsyncMock),
+        patch("squishmark.main.close_db", new_callable=AsyncMock),
     ):
         from squishmark.main import create_app
 
         app = create_app()
-        transport = ASGITransport(app=app)
-
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            response = await client.get("/pygments.css")
+        # ASGITransport does not emit lifespan events, so run the lifespan
+        # explicitly to build the service container on app.state.
+        async with app.router.lifespan_context(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/pygments.css")
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/css; charset=utf-8"
         assert response.headers["cache-control"] == "public, max-age=86400"
         assert ".highlight" in response.text
-
-    reset_markdown_service()

--- a/tests/test_routes_assets.py
+++ b/tests/test_routes_assets.py
@@ -12,8 +12,10 @@ from squishmark.services.github import GitHubBinaryFile
 @asynccontextmanager
 async def _client_with_github(mock_github: AsyncMock):
     """Build the app with the GitHub service in the container mocked."""
-    # Theme engine loads custom templates during the lifespan.
+    # Theme engine loads custom templates during the lifespan; the startup
+    # theme log reads the config (None renders defaults).
     mock_github.list_directory.return_value = []
+    mock_github.get_config.return_value = None
     with (
         patch("squishmark.services.container.create_github_service", return_value=mock_github),
         patch("squishmark.main.init_db", new_callable=AsyncMock),

--- a/tests/test_routes_assets.py
+++ b/tests/test_routes_assets.py
@@ -11,14 +11,23 @@ from squishmark.services.github import GitHubBinaryFile
 
 @asynccontextmanager
 async def _client_with_github(mock_github: AsyncMock):
-    """Build the app with the assets router's GitHub service mocked."""
-    with patch("squishmark.routers.assets.get_github_service", return_value=mock_github):
+    """Build the app with the GitHub service in the container mocked."""
+    # Theme engine loads custom templates during the lifespan.
+    mock_github.list_directory.return_value = []
+    with (
+        patch("squishmark.services.container.create_github_service", return_value=mock_github),
+        patch("squishmark.main.init_db", new_callable=AsyncMock),
+        patch("squishmark.main.close_db", new_callable=AsyncMock),
+    ):
         from squishmark.main import create_app
 
         app = create_app()
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            yield client
+        # ASGITransport does not emit lifespan events, so run the lifespan
+        # explicitly to build the service container on app.state.
+        async with app.router.lifespan_context(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                yield client
 
 
 @pytest.mark.asyncio

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -1,13 +1,14 @@
 """Tests for SEO routes: sitemap.xml and robots.txt."""
 
 import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from xml.etree.ElementTree import fromstring
 
 import pytest
 
 from squishmark.models.content import Config, Page, Post
 from squishmark.routers.seo import _build_robots_txt, _build_sitemap
+from squishmark.services.container import Services
 
 SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 
@@ -15,6 +16,11 @@ SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
 def _ns(tag: str) -> str:
     """Prefix a tag with the sitemap namespace."""
     return f"{{{SITEMAP_NS}}}{tag}"
+
+
+def _services(github: AsyncMock, cache: AsyncMock) -> Services:
+    """Build a service container wrapping the given github and cache mocks."""
+    return Services(settings=MagicMock(), cache=cache, github=github)
 
 
 @pytest.fixture
@@ -209,18 +215,12 @@ class TestSitemapEndpoint:
         mock_github.get_config.return_value = {"site": {"title": "Test"}}
         mock_github.list_directory.return_value = []
 
-        with (
-            patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.seo import sitemap_xml
+        from squishmark.routers.seo import sitemap_xml
 
-            response = await sitemap_xml()
+        response = await sitemap_xml(_services(mock_github, mock_cache))
 
         assert "application/xml" in response.media_type
 
@@ -228,14 +228,12 @@ class TestSitemapEndpoint:
     async def test_cached_response_returned(self):
         cached_xml = b'<?xml version="1.0"?><urlset>cached</urlset>'
 
-        with patch("squishmark.routers.seo.get_cache") as mock_cache_fn:
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = cached_xml
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = cached_xml
 
-            from squishmark.routers.seo import sitemap_xml
+        from squishmark.routers.seo import sitemap_xml
 
-            response = await sitemap_xml()
+        response = await sitemap_xml(_services(AsyncMock(), mock_cache))
 
         assert response.body == cached_xml
 
@@ -256,18 +254,12 @@ class TestSitemapEndpoint:
             MagicMock(content="---\ntitle: Draft\ndate: 2026-01-02\ndraft: true\n---\nDraft."),
         ]
 
-        with (
-            patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.seo import sitemap_xml
+        from squishmark.routers.seo import sitemap_xml
 
-            response = await sitemap_xml()
+        response = await sitemap_xml(_services(mock_github, mock_cache))
 
         root = fromstring(response.body)
         locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
@@ -281,18 +273,12 @@ class TestRobotsEndpoint:
         mock_github = AsyncMock()
         mock_github.get_config.return_value = {"site": {"title": "Test"}}
 
-        with (
-            patch("squishmark.routers.seo.get_github_service", return_value=mock_github),
-            patch("squishmark.services.content.get_github_service", return_value=mock_github),
-            patch("squishmark.routers.seo.get_cache") as mock_cache_fn,
-        ):
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = None
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
 
-            from squishmark.routers.seo import robots_txt
+        from squishmark.routers.seo import robots_txt
 
-            response = await robots_txt()
+        response = await robots_txt(_services(mock_github, mock_cache))
 
         assert "text/plain" in response.media_type
 
@@ -300,13 +286,11 @@ class TestRobotsEndpoint:
     async def test_cached_response_returned(self):
         cached_txt = "User-agent: *\nAllow: /\n"
 
-        with patch("squishmark.routers.seo.get_cache") as mock_cache_fn:
-            mock_cache = AsyncMock()
-            mock_cache.get.return_value = cached_txt
-            mock_cache_fn.return_value = mock_cache
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = cached_txt
 
-            from squishmark.routers.seo import robots_txt
+        from squishmark.routers.seo import robots_txt
 
-            response = await robots_txt()
+        response = await robots_txt(_services(AsyncMock(), mock_cache))
 
         assert response.body.decode() == cached_txt

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -207,3 +207,5 @@ class TestReload:
         github.get_file = AsyncMock(return_value=GitHubFile(path="theme/snippet.html", content="V2"))
         await engine.reload()
         assert engine.render_partial("snippet.html", theme_override="default") == "V2"
+        # reload must bypass the content cache, not rely on callers clearing it
+        github.get_file.assert_called_with("theme/snippet.html", use_cache=False)

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -8,6 +8,8 @@ import pytest
 from jinja2 import TemplateNotFound
 
 from squishmark.models.content import Config
+from squishmark.services.cache import Cache
+from squishmark.services.container import Services
 from squishmark.services.theme.engine import ThemeEngine
 from squishmark.services.theme.loader import (
     AsyncHybridLoader,
@@ -142,7 +144,11 @@ class TestThemedEnvironmentJoinPath:
 def _make_engine(themes_path: Path) -> ThemeEngine:
     github_service = MagicMock()
     github_service.list_directory = AsyncMock(return_value=[])
-    engine = ThemeEngine(github_service, themes_path=themes_path)
+    github_service.get_config = AsyncMock(return_value={})
+    # get_nav_pages reaches the cached content layer through services; an empty
+    # pages listing yields an empty navbar.
+    services = Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=github_service)
+    engine = ThemeEngine(github_service, themes_path=themes_path, services=services)
 
     # Favicon detection is an await point in render(); yield control there so
     # concurrent renders interleave (this is where the old shared state raced).

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -148,7 +148,7 @@ def _make_engine(themes_path: Path) -> ThemeEngine:
     # get_nav_pages reaches the cached content layer through services; an empty
     # pages listing yields an empty navbar.
     services = Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=github_service)
-    engine = ThemeEngine(github_service, themes_path=themes_path, services=services)
+    engine = ThemeEngine(services, themes_path=themes_path)
 
     # Favicon detection is an await point in render(); yield control there so
     # concurrent renders interleave (this is where the old shared state raced).
@@ -186,3 +186,24 @@ class TestConcurrentRenders:
             "BASE:terminal",
             "BASE:blue-tech",
         ]
+
+
+class TestReload:
+    @pytest.mark.asyncio
+    async def test_reload_picks_up_edited_custom_template(self, tmp_path: Path):
+        """reload() must serve the new custom template source, not Jinja's
+        cached compile (custom templates report uptodate=True)."""
+        from squishmark.services.github import GitHubFile
+
+        _build_themes(tmp_path)
+        engine = _make_engine(tmp_path)
+        github = engine.github_service
+        github.list_directory = AsyncMock(return_value=["theme/snippet.html"])
+        github.get_file = AsyncMock(return_value=GitHubFile(path="theme/snippet.html", content="V1"))
+
+        await engine.load_custom_templates()
+        assert engine.render_partial("snippet.html", theme_override="default") == "V1"
+
+        github.get_file = AsyncMock(return_value=GitHubFile(path="theme/snippet.html", content="V2"))
+        await engine.reload()
+        assert engine.render_partial("snippet.html", theme_override="default") == "V2"


### PR DESCRIPTION
Closes #108
Closes #121

Replaces the five module-level service singletons (github, cache, markdown, theme engine, livereload) with FastAPI-idiomatic dependency injection:

- New `services/container.py`: a `Services` dataclass built once in the lifespan via `build_services()` and hung on `app.state`; includes a lazy `markdown_for(config)` factory that preserves today's first-config pygments behavior (revisited by #109) and a `create_github_service` seam that tests patch to inject fakes
- `dependencies.py` gains `ServicesDep` and `ThemeEngineDep`, both reading `request.app.state`; all routers consume them
- The cached content layer, search index, and warm functions take the container explicitly, so request paths and webhook/admin warm paths share one mechanism
- `ThemeEngine` takes the container as its sole dependency; `reset_theme_engine()` is replaced by `ThemeEngine.reload()`, which also clears Jinja's compiled-template cache (custom templates report uptodate=True, so without this an edited content-repo template kept serving stale after a webhook refresh; regression test included)
- Theme observability: startup INFO log of the configured theme, DEBUG log per render with the resolved theme and template (#121, found during verification)
- All `get_x`/`reset_x`/`shutdown_x` shims deleted; conftest injects fakes by patching the factory seam instead of poking module globals

Verification: checks green (365 tests, pyright clean). Live server on the branch: all route families (posts, post detail, pages, feed, sitemap, search, assets, pygments, health), admin dashboard with auth bypass, admin cache refresh end to end (clears, reloads theme engine, warms content and search caches), and all three bundled themes serving their own assets on index and post pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
