### PR TITLE
fix(markdown): follow pygments_style config changes without restart

### DIFF
--- a/src/squishmark/services/container.py
+++ b/src/squishmark/services/container.py
@@ -26,14 +26,16 @@ class Services:
     _markdown: MarkdownService | None = None
 
     def markdown_for(self, config: Config) -> MarkdownService:
-        """Return the markdown service, building it once from the first config.
+        """Return the markdown service, rebuilding it when the pygments style changes.
 
-        The pygments_style is fixed by the first config seen and reused for the
-        app's life (issue #109 revisits this): behavior matches the previous
-        module-global get_markdown_service.
+        The service is cheap to construct, so it is (re)built whenever
+        ``config.theme.pygments_style`` differs from the style it was built with.
+        This lets a config edit to ``pygments_style`` take effect after an admin
+        cache refresh or webhook (which return fresh config) without a restart.
         """
-        if self._markdown is None:
-            self._markdown = MarkdownService(pygments_style=config.theme.pygments_style)
+        style = config.theme.pygments_style
+        if self._markdown is None or self._markdown.pygments_style != style:
+            self._markdown = MarkdownService(pygments_style=style)
         return self._markdown
 
 

--- a/tests/test_pygments_css.py
+++ b/tests/test_pygments_css.py
@@ -171,3 +171,34 @@ async def test_pygments_css_route_follows_config_change():
         assert second.status_code == 200
         assert first.text != second.text
         assert second.text == MarkdownService(pygments_style="monokai").get_pygments_css()
+
+
+@pytest.mark.asyncio
+async def test_pygments_style_follows_cache_refresh(tmp_path):
+    """The production refresh path with real caching: a config.yml edit stays
+    invisible while the config is cached, then takes effect after cache.clear()
+    (what the admin refresh and webhook do), with no restart."""
+    from squishmark.config import Settings
+    from squishmark.services.cache import Cache
+    from squishmark.services.container import Services
+    from squishmark.services.github import GitHubService
+
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("theme:\n  pygments_style: github-dark\n", encoding="utf-8")
+
+    settings = Settings(github_content_repo=f"file://{tmp_path}")
+    cache = Cache(ttl_seconds=300)
+    services = Services(settings=settings, cache=cache, github=GitHubService(settings, cache))
+
+    config = Config.from_dict(await services.github.get_config())
+    assert services.markdown_for(config).pygments_style == "github-dark"
+
+    # Edit config.yml on disk: still cached, so the old style keeps serving.
+    config_file.write_text("theme:\n  pygments_style: monokai\n", encoding="utf-8")
+    config = Config.from_dict(await services.github.get_config())
+    assert services.markdown_for(config).pygments_style == "github-dark"
+
+    # The refresh (admin/webhook) clears the cache: new style takes effect.
+    await cache.clear()
+    config = Config.from_dict(await services.github.get_config())
+    assert services.markdown_for(config).pygments_style == "monokai"

--- a/tests/test_pygments_css.py
+++ b/tests/test_pygments_css.py
@@ -5,7 +5,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from squishmark.config import Settings
 from squishmark.models.content import Config, ThemeConfig
+from squishmark.services.container import build_services
 from squishmark.services.markdown import MarkdownService
 from squishmark.services.theme.engine import THEME_PYGMENTS_DEFAULTS, ThemeEngine
 
@@ -74,6 +76,31 @@ def test_get_pygments_css_custom_style():
 
 
 # ---------------------------------------------------------------------------
+# Regression: Services.markdown_for follows config.pygments_style (issue #109)
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_for_rebuilds_when_style_changes():
+    """markdown_for must track the current config style, not freeze on the first."""
+    services = build_services(Settings())
+
+    md_a = services.markdown_for(Config(theme=ThemeConfig(pygments_style="monokai")))
+    assert md_a.pygments_style == "monokai"
+
+    md_b = services.markdown_for(Config(theme=ThemeConfig(pygments_style="dracula")))
+    assert md_b.pygments_style == "dracula"
+    assert md_a.get_pygments_css() != md_b.get_pygments_css()
+
+
+def test_markdown_for_reuses_service_when_style_unchanged():
+    """An unchanged style returns the same instance (cheap, but not churned)."""
+    services = build_services(Settings())
+    config = Config(theme=ThemeConfig(pygments_style="monokai"))
+
+    assert services.markdown_for(config) is services.markdown_for(config)
+
+
+# ---------------------------------------------------------------------------
 # Integration test for /pygments.css route
 # ---------------------------------------------------------------------------
 
@@ -107,3 +134,40 @@ async def test_pygments_css_route():
         assert response.headers["content-type"] == "text/css; charset=utf-8"
         assert response.headers["cache-control"] == "public, max-age=86400"
         assert ".highlight" in response.text
+
+
+@pytest.mark.asyncio
+async def test_pygments_css_route_follows_config_change():
+    """A pygments_style change takes effect on the next request without restart.
+
+    Simulates the admin refresh / webhook path: after cache.clear() the next
+    get_config() returns fresh config, so /pygments.css must serve the new style.
+    """
+    mock_github = AsyncMock()
+    mock_github.get_config.return_value = {
+        "theme": {"name": "default", "pygments_style": "dracula"},
+    }
+    mock_github.list_directory.return_value = []
+
+    with (
+        patch("squishmark.services.container.create_github_service", return_value=mock_github),
+        patch("squishmark.main.init_db", new_callable=AsyncMock),
+        patch("squishmark.main.close_db", new_callable=AsyncMock),
+    ):
+        from squishmark.main import create_app
+
+        app = create_app()
+        async with app.router.lifespan_context(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                first = await client.get("/pygments.css")
+                # Config edit surfaces as fresh get_config output post cache clear.
+                mock_github.get_config.return_value = {
+                    "theme": {"name": "default", "pygments_style": "monokai"},
+                }
+                second = await client.get("/pygments.css")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.text != second.text
+        assert second.text == MarkdownService(pygments_style="monokai").get_pygments_css()


### PR DESCRIPTION
Closes #109

Services.markdown_for memoized the MarkdownService on the first config seen, permanently freezing pygments_style; the admin cache refresh and webhook never rebuilt it, so a config edit had no effect until restart.

markdown_for now rebuilds the service whenever the incoming config's pygments_style differs from the one it was built with (sub-millisecond construction), and reuses the instance when unchanged. No router or dependency changes needed.

Tests: rebuild-on-change, reuse-when-unchanged, and a route-level test that /pygments.css serves the new style after a config change. Live-verified on a dev server: editing pygments_style in config.yml changed the served CSS with no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)