### PR TITLE
refactor(deps): add SiteContext dependency to remove per-route config ritual

### DIFF
--- a/src/squishmark/dependencies.py
+++ b/src/squishmark/dependencies.py
@@ -40,7 +40,11 @@ class SiteContext:
 
     @property
     def markdown(self) -> MarkdownService:
-        """Return the markdown service, built once from this request's config."""
+        """Return the markdown service for this request's config.
+
+        Caching lives in ``Services.markdown_for``; see it for how config
+        changes affect the instance.
+        """
         return self.services.markdown_for(self.config)
 
 

--- a/src/squishmark/dependencies.py
+++ b/src/squishmark/dependencies.py
@@ -1,12 +1,15 @@
 """FastAPI dependency injection utilities."""
 
 import logging
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request
 
 from squishmark.config import Settings, get_settings
+from squishmark.models.content import Config
 from squishmark.services.container import Services
+from squishmark.services.markdown import MarkdownService
 from squishmark.services.theme import ThemeEngine
 
 logger = logging.getLogger(__name__)
@@ -21,6 +24,33 @@ def get_services(request: Request) -> Services:
 
 
 ServicesDep = Annotated[Services, Depends(get_services)]
+
+
+@dataclass
+class SiteContext:
+    """Per-request site context: the parsed config plus the services bundle.
+
+    Folds the config-fetch ritual (``get_config`` + ``Config.from_dict``) that
+    most routes repeat into one dependency. The markdown service is exposed
+    lazily so config-only routes never build it.
+    """
+
+    config: Config
+    services: Services
+
+    @property
+    def markdown(self) -> MarkdownService:
+        """Return the markdown service, built once from this request's config."""
+        return self.services.markdown_for(self.config)
+
+
+async def get_site_context(services: ServicesDep) -> SiteContext:
+    """Fetch and parse the site config, pairing it with the services bundle."""
+    config_data = await services.github.get_config()
+    return SiteContext(config=Config.from_dict(config_data), services=services)
+
+
+SiteContextDep = Annotated[SiteContext, Depends(get_site_context)]
 
 
 def get_theme_engine(request: Request) -> ThemeEngine:

--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from squishmark.config import get_settings
-from squishmark.dependencies import AdminUser, ServicesDep, ThemeEngineDep, is_htmx
+from squishmark.dependencies import AdminUser, ServicesDep, SiteContextDep, ThemeEngineDep, is_htmx
 from squishmark.models.content import Config
 from squishmark.models.db import Note, get_db_session
 from squishmark.services.analytics import AnalyticsService
@@ -180,13 +180,11 @@ async def admin_dashboard(
     request: Request,
     admin: AdminUser,
     session: DbSession,
-    services: ServicesDep,
+    context: SiteContextDep,
     theme_engine: ThemeEngineDep,
 ) -> HTMLResponse:
     """Render the admin dashboard."""
-    # Get config
-    config_data = await services.github.get_config()
-    config = Config.from_dict(config_data)
+    config = context.config
 
     # Get analytics
     analytics_service = AnalyticsService(session)
@@ -197,7 +195,7 @@ async def admin_dashboard(
     notes = await notes_service.get_all()
 
     # Get cache info
-    cache = services.cache
+    cache = context.services.cache
 
     # Render admin template
     csrf_token = get_or_create_csrf_token(request)

--- a/src/squishmark/routers/assets.py
+++ b/src/squishmark/routers/assets.py
@@ -7,8 +7,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse, Response
 
 from squishmark.config import get_settings
-from squishmark.dependencies import ServicesDep
-from squishmark.models.content import Config
+from squishmark.dependencies import ServicesDep, SiteContextDep
 
 router = APIRouter(tags=["assets"])
 
@@ -38,12 +37,9 @@ async def serve_favicon(services: ServicesDep) -> Response:
 
 # Dynamic Pygments CSS - generates syntax highlighting styles from config
 @router.get("/pygments.css")
-async def serve_pygments_css(services: ServicesDep) -> Response:
+async def serve_pygments_css(context: SiteContextDep) -> Response:
     """Serve dynamically generated Pygments CSS based on configured style."""
-    config_data = await services.github.get_config()
-    config = Config.from_dict(config_data)
-    md_service = services.markdown_for(config)
-    css = md_service.get_pygments_css()
+    css = context.markdown.get_pygments_css()
     return Response(
         content=css,
         media_type="text/css",

--- a/src/squishmark/routers/pages.py
+++ b/src/squishmark/routers/pages.py
@@ -4,8 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from squishmark.dependencies import ServicesDep, ThemeEngineDep, is_admin
-from squishmark.models.content import Config
+from squishmark.dependencies import SiteContextDep, ThemeEngineDep, is_admin
 from squishmark.models.db import get_db_session
 from squishmark.services.content import get_cached_posts, get_featured_posts
 from squishmark.services.notes import NotesService
@@ -16,7 +15,7 @@ router = APIRouter(tags=["pages"])
 @router.get("/{slug}", response_class=HTMLResponse)
 async def get_page(
     request: Request,
-    services: ServicesDep,
+    context: SiteContextDep,
     theme_engine: ThemeEngineDep,
     slug: str,
     db: AsyncSession = Depends(get_db_session),
@@ -27,16 +26,12 @@ async def get_page(
     This route has lower priority than /posts routes and is designed
     to be a catch-all for pages like /about, /contact, etc.
     """
-    # Get config
-    config_data = await services.github.get_config()
-    config = Config.from_dict(config_data)
-
-    # Get markdown service with config
-    markdown_service = services.markdown_for(config)
+    config = context.config
+    markdown_service = context.markdown
 
     # Try to find the page
     page_path = f"pages/{slug}.md"
-    file = await services.github.get_file(page_path)
+    file = await context.services.github.get_file(page_path)
 
     if file is None:
         raise HTTPException(status_code=404, detail="Page not found")
@@ -54,7 +49,7 @@ async def get_page(
     notes = await notes_service.get_for_path(f"/{slug}", include_private=admin)
 
     # Featured posts for template context (published only, shown to everyone)
-    all_posts = await get_cached_posts(services, include_drafts=False)
+    all_posts = await get_cached_posts(context.services, include_drafts=False)
     featured = get_featured_posts(all_posts, config.site)
 
     # Render

--- a/src/squishmark/routers/posts.py
+++ b/src/squishmark/routers/posts.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from squishmark.dependencies import ServicesDep, ThemeEngineDep, is_admin
-from squishmark.models.content import Config, Pagination
+from squishmark.dependencies import SiteContextDep, ThemeEngineDep, is_admin
+from squishmark.models.content import Pagination
 from squishmark.models.db import get_db_session
 from squishmark.services.content import build_series_context, get_cached_posts, get_featured_posts
 from squishmark.services.notes import NotesService
@@ -16,18 +16,16 @@ router = APIRouter(prefix="/posts", tags=["posts"])
 @router.get("", response_class=HTMLResponse)
 async def list_posts(
     request: Request,
-    services: ServicesDep,
+    context: SiteContextDep,
     theme_engine: ThemeEngineDep,
     page: int = Query(1, ge=1),
 ) -> HTMLResponse:
     """List all published posts with pagination."""
-    # Get config
-    config_data = await services.github.get_config()
-    config = Config.from_dict(config_data)
+    config = context.config
 
     # Get all posts (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_cached_posts(services, include_drafts=include_drafts)
+    all_posts = await get_cached_posts(context.services, include_drafts=include_drafts)
 
     # Paginate
     per_page = config.posts.per_page
@@ -60,19 +58,17 @@ async def list_posts(
 @router.get("/{slug}", response_class=HTMLResponse)
 async def get_post(
     request: Request,
-    services: ServicesDep,
+    context: SiteContextDep,
     theme_engine: ThemeEngineDep,
     slug: str,
     db: AsyncSession = Depends(get_db_session),
 ) -> HTMLResponse:
     """Get a single post by slug."""
-    # Get config
-    config_data = await services.github.get_config()
-    config = Config.from_dict(config_data)
+    config = context.config
 
     # Get all posts and find the matching one (admins can see drafts)
     include_drafts = is_admin(request)
-    all_posts = await get_cached_posts(services, include_drafts=include_drafts)
+    all_posts = await get_cached_posts(context.services, include_drafts=include_drafts)
 
     post = next((p for p in all_posts if p.slug == slug), None)
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,37 @@
+"""Tests for the SiteContext request dependency."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from squishmark.dependencies import SiteContext, get_site_context
+from squishmark.models.content import Config
+from squishmark.services.cache import Cache
+from squishmark.services.container import Services
+from squishmark.services.markdown import MarkdownService
+
+
+def _services(config: dict) -> Services:
+    github = MagicMock()
+    github.get_config = AsyncMock(return_value=config)
+    return Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=github)
+
+
+async def test_get_site_context_parses_config() -> None:
+    services = _services({"site": {"title": "Test Blog"}})
+
+    context = await get_site_context(services)
+
+    assert isinstance(context, SiteContext)
+    assert isinstance(context.config, Config)
+    assert context.config.site.title == "Test Blog"
+    assert context.services is services
+    services.github.get_config.assert_awaited_once()
+
+
+async def test_site_context_markdown_is_lazy_and_cached() -> None:
+    services = _services({"site": {"title": "Test Blog"}})
+    context = await get_site_context(services)
+
+    md = context.markdown
+    assert isinstance(md, MarkdownService)
+    # The property delegates to Services.markdown_for, which caches the instance.
+    assert context.markdown is md

--- a/tests/test_nav_pages.py
+++ b/tests/test_nav_pages.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
+from squishmark.dependencies import SiteContext
 from squishmark.models.content import Config, FrontMatter, Page, ThemeConfig
 from squishmark.services.container import Services
 from squishmark.services.markdown import MarkdownService
@@ -85,9 +86,10 @@ class TestHiddenPage404:
             mock_github.get_file.return_value = MagicMock(content=hidden_content)
             mock_notes_cls.return_value = AsyncMock()
             services = Services(settings=MagicMock(), cache=AsyncMock(), github=mock_github)
+            context = SiteContext(config=Config(), services=services)
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_page(mock_request, services, AsyncMock(), "secret", db=AsyncMock())
+                await get_page(mock_request, context, AsyncMock(), "secret", db=AsyncMock())
 
             assert exc_info.value.status_code == 404
 
@@ -111,8 +113,9 @@ class TestHiddenPage404:
             mock_engine.render_page.return_value = "<html>Unlisted</html>"
 
             services = Services(settings=MagicMock(), cache=AsyncMock(), github=mock_github)
+            context = SiteContext(config=Config(), services=services)
             mock_request = MagicMock()
-            response = await get_page(mock_request, services, mock_engine, "unlisted", db=AsyncMock())
+            response = await get_page(mock_request, context, mock_engine, "unlisted", db=AsyncMock())
 
             assert response.status_code == 200
 

--- a/tests/test_notes_rendering.py
+++ b/tests/test_notes_rendering.py
@@ -4,6 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from squishmark.dependencies import SiteContext
+from squishmark.models.content import Config
 from squishmark.services.cache import Cache
 from squishmark.services.container import Services
 
@@ -34,6 +36,12 @@ def _services(mock_github: AsyncMock) -> Services:
     return Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=mock_github)
 
 
+def _site_context(mock_github: AsyncMock) -> SiteContext:
+    """Wrap the github mock in a SiteContext for direct handler calls."""
+    config = Config.from_dict(mock_github.get_config.return_value)
+    return SiteContext(config=config, services=_services(mock_github))
+
+
 class TestPostNotesRendering:
     """Tests for notes being fetched and passed to templates on post pages."""
 
@@ -56,7 +64,7 @@ class TestPostNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _site_context(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=False)
 
@@ -79,7 +87,7 @@ class TestPostNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_admin_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
+            await get_post(_admin_request(), _site_context(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=True)
 
@@ -102,7 +110,7 @@ class TestPostNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _site_context(mock_github), engine, "my-post", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/posts/my-post", include_private=False)
 
@@ -127,7 +135,7 @@ class TestPostNotesRendering:
             engine = AsyncMock()
             engine.render_post.return_value = "<html></html>"
 
-            await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
+            await get_post(_anonymous_request(), _site_context(mock_github), engine, "my-post", db=AsyncMock())
 
             # Verify notes were passed as the third positional arg to render_post
             call_args = engine.render_post.call_args
@@ -152,7 +160,9 @@ class TestPostNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_post=AsyncMock(return_value="<html></html>"))
 
-            response = await get_post(_anonymous_request(), _services(mock_github), engine, "my-post", db=AsyncMock())
+            response = await get_post(
+                _anonymous_request(), _site_context(mock_github), engine, "my-post", db=AsyncMock()
+            )
 
             assert response.status_code == 200
             call_args = engine.render_post.call_args
@@ -181,7 +191,7 @@ class TestPageNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
+            await get_page(_anonymous_request(), _site_context(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=False)
 
@@ -204,7 +214,7 @@ class TestPageNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_admin_request(), _services(mock_github), engine, "about", db=AsyncMock())
+            await get_page(_admin_request(), _site_context(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=True)
 
@@ -227,7 +237,7 @@ class TestPageNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
+            await get_page(_anonymous_request(), _site_context(mock_github), engine, "about", db=AsyncMock())
 
             mock_notes.get_for_path.assert_called_once_with("/about", include_private=False)
 
@@ -252,7 +262,7 @@ class TestPageNotesRendering:
             engine = AsyncMock()
             engine.render_page.return_value = "<html></html>"
 
-            await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
+            await get_page(_anonymous_request(), _site_context(mock_github), engine, "about", db=AsyncMock())
 
             call_args = engine.render_page.call_args
             assert call_args[0][2] == fake_notes
@@ -276,7 +286,7 @@ class TestPageNotesRendering:
             mock_notes_cls.return_value = mock_notes
             engine = AsyncMock(render_page=AsyncMock(return_value="<html></html>"))
 
-            response = await get_page(_anonymous_request(), _services(mock_github), engine, "about", db=AsyncMock())
+            response = await get_page(_anonymous_request(), _site_context(mock_github), engine, "about", db=AsyncMock())
 
             assert response.status_code == 200
             call_args = engine.render_page.call_args


### PR DESCRIPTION
Closes #112

Adds a SiteContext dependency (parsed config plus the services bundle, markdown service exposed as a lazy property) so routes stop repeating the get_config / Config.from_dict / markdown_for ritual. Posts, pages, admin dashboard, and /pygments.css now consume SiteContextDep.

Deliberately left on ServicesDep: feed.xml, sitemap.xml, and robots.txt check their response caches before fetching config; the eager dependency would add a config fetch on every cache hit, a behavior change.

Checks green (367 tests, pyright clean). Live smoke on the branch: posts, post detail, page, pygments, admin, feed, sitemap all serve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)