### PR TITLE
feat(search): add fuzzy match tier for typo tolerance

### DIFF
--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -148,28 +148,23 @@ def _fuzzy_matches(query_token: str, field_tokens: frozenset[str]) -> bool:
     return False
 
 
-def _field_score(
-    query_token: str, field_tokens: frozenset[str], exact_weight: int, prefix_weight: int, fuzzy_weight: int
-) -> tuple[int, bool]:
-    """Score one query token against one field: exact > prefix > fuzzy.
-
-    Returns (score, used_fuzzy) so the caller can rank fuzzy-dependent
-    posts behind posts with real matches.
-    """
+def _field_score(query_token: str, field_tokens: frozenset[str], exact_weight: int, prefix_weight: int) -> int:
+    """Score one query token against one field: exact tier wins over prefix."""
     if query_token in field_tokens:
-        return exact_weight, False
+        return exact_weight
     if any(token.startswith(query_token) for token in field_tokens):
-        return prefix_weight, False
-    if _fuzzy_matches(query_token, field_tokens):
-        return fuzzy_weight, True
-    return 0, False
+        return prefix_weight
+    return 0
 
 
 def _score_post(query_tokens: list[str], indexed: IndexedPost) -> tuple[int, bool]:
     """Sum field scores per query token; total 0 when any token matches nothing (AND).
 
-    Returns (total, used_fuzzy); used_fuzzy is True when at least one
-    token matched only via the fuzzy tier in every field it hit.
+    Fuzzy is a pure fallback: it is only evaluated for a token with no
+    exact/prefix match in any field, so fuzzy hits never perturb ordering
+    among real-match posts and cost nothing on queries with real hits.
+    Returns (total, used_fuzzy); used_fuzzy is True when any token needed
+    the fallback.
     """
     fields = (
         (indexed.title_tokens, *_WEIGHTS["title"]),
@@ -180,16 +175,15 @@ def _score_post(query_tokens: list[str], indexed: IndexedPost) -> tuple[int, boo
     total = 0
     used_fuzzy = False
     for query_token in query_tokens:
-        token_score = 0
-        token_real_match = False
-        for field_tokens, exact, prefix, fuzzy in fields:
-            score, field_fuzzy = _field_score(query_token, field_tokens, exact, prefix, fuzzy)
-            token_score += score
-            if score > 0 and not field_fuzzy:
-                token_real_match = True
+        token_score = sum(
+            _field_score(query_token, field_tokens, exact, prefix) for field_tokens, exact, prefix, _ in fields
+        )
         if token_score == 0:
-            return 0, False
-        if not token_real_match:
+            token_score = sum(
+                fuzzy for field_tokens, _, _, fuzzy in fields if _fuzzy_matches(query_token, field_tokens)
+            )
+            if token_score == 0:
+                return 0, False
             used_fuzzy = True
         total += token_score
     return total, used_fuzzy

--- a/src/squishmark/services/search.py
+++ b/src/squishmark/services/search.py
@@ -8,6 +8,7 @@ filters drafts.
 """
 
 import datetime
+import difflib
 import re
 from dataclasses import dataclass
 
@@ -41,15 +42,26 @@ _MD_REF_DEF_RE = re.compile(r"^[ \t]*\[[^\]]+\]:\s+\S+.*$", re.MULTILINE)
 _HTML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
 _BARE_URL_RE = re.compile(r"(?:https?://|www\.)\S+")
 
-# Presence-based weights per (field, tier). Exact beats prefix within a
-# field; title beats tags beats description beats body across fields. No
-# term frequency — long bodies must not outrank a title hit.
+# Presence-based weights per (field, tier): exact, prefix, fuzzy. Exact
+# beats prefix beats fuzzy within a field; title beats tags beats
+# description beats body across fields. No term frequency: long bodies
+# must not outrank a title hit. Weights alone cannot make every fuzzy hit
+# rank below every real hit across fields (a fuzzy title would outscore an
+# exact body), so query_index additionally sorts posts that needed any
+# fuzzy match behind posts matched entirely by exact/prefix; these weights
+# only order posts within the same class.
 _WEIGHTS = {
-    "title": (12, 8),
-    "tags": (10, 6),
-    "description": (5, 3),
-    "body": (2, 1),
+    "title": (12, 8, 6),
+    "tags": (10, 6, 4),
+    "description": (5, 3, 2),
+    "body": (2, 1, 1),
 }
+
+# Fuzzy tier thresholds. Tokens shorter than 4 chars are excluded: a
+# single edit rewrites too much of a short token and false positives
+# dominate (e.g. "cat" would match "car").
+FUZZY_MIN_TOKEN_LENGTH = 4
+FUZZY_RATIO_THRESHOLD = 0.8
 
 
 def tokenize(text: str) -> set[str]:
@@ -121,17 +133,44 @@ def build_search_index(posts: list[Post]) -> list[IndexedPost]:
     return index
 
 
-def _field_score(query_token: str, field_tokens: frozenset[str], exact_weight: int, prefix_weight: int) -> int:
-    """Score one query token against one field: exact tier wins over prefix."""
+def _fuzzy_matches(query_token: str, field_tokens: frozenset[str]) -> bool:
+    """True when any field token is within FUZZY_RATIO_THRESHOLD of the query token."""
+    if len(query_token) < FUZZY_MIN_TOKEN_LENGTH:
+        return False
+    # seq2 is the cached side of SequenceMatcher, so fix the query token
+    # there and swap candidates through seq1. real_quick_ratio is a cheap
+    # upper bound that skips most candidates before the O(n*m) ratio call.
+    matcher = difflib.SequenceMatcher(None, "", query_token)
+    for token in field_tokens:
+        matcher.set_seq1(token)
+        if matcher.real_quick_ratio() >= FUZZY_RATIO_THRESHOLD and matcher.ratio() >= FUZZY_RATIO_THRESHOLD:
+            return True
+    return False
+
+
+def _field_score(
+    query_token: str, field_tokens: frozenset[str], exact_weight: int, prefix_weight: int, fuzzy_weight: int
+) -> tuple[int, bool]:
+    """Score one query token against one field: exact > prefix > fuzzy.
+
+    Returns (score, used_fuzzy) so the caller can rank fuzzy-dependent
+    posts behind posts with real matches.
+    """
     if query_token in field_tokens:
-        return exact_weight
+        return exact_weight, False
     if any(token.startswith(query_token) for token in field_tokens):
-        return prefix_weight
-    return 0
+        return prefix_weight, False
+    if _fuzzy_matches(query_token, field_tokens):
+        return fuzzy_weight, True
+    return 0, False
 
 
-def _score_post(query_tokens: list[str], indexed: IndexedPost) -> int:
-    """Sum field scores per query token; 0 when any token matches nothing (AND)."""
+def _score_post(query_tokens: list[str], indexed: IndexedPost) -> tuple[int, bool]:
+    """Sum field scores per query token; total 0 when any token matches nothing (AND).
+
+    Returns (total, used_fuzzy); used_fuzzy is True when at least one
+    token matched only via the fuzzy tier in every field it hit.
+    """
     fields = (
         (indexed.title_tokens, *_WEIGHTS["title"]),
         (indexed.tag_tokens, *_WEIGHTS["tags"]),
@@ -139,21 +178,30 @@ def _score_post(query_tokens: list[str], indexed: IndexedPost) -> int:
         (indexed.body_tokens, *_WEIGHTS["body"]),
     )
     total = 0
+    used_fuzzy = False
     for query_token in query_tokens:
-        token_score = sum(
-            _field_score(query_token, field_tokens, exact, prefix) for field_tokens, exact, prefix in fields
-        )
+        token_score = 0
+        token_real_match = False
+        for field_tokens, exact, prefix, fuzzy in fields:
+            score, field_fuzzy = _field_score(query_token, field_tokens, exact, prefix, fuzzy)
+            token_score += score
+            if score > 0 and not field_fuzzy:
+                token_real_match = True
         if token_score == 0:
-            return 0
+            return 0, False
+        if not token_real_match:
+            used_fuzzy = True
         total += token_score
-    return total
+    return total, used_fuzzy
 
 
 def query_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:
     """Rank indexed posts against the query; top ``limit`` results.
 
-    Every query token must match somewhere (exact or prefix) for a post to
-    qualify. Ties break by date descending, dateless posts last.
+    Every query token must match somewhere (exact, prefix, or fuzzy) for a
+    post to qualify. Posts needing any fuzzy match rank behind posts
+    matched entirely by exact/prefix. Ties break by date descending,
+    dateless posts last.
     """
     if len(query.strip()) < MIN_QUERY_LENGTH:
         return []
@@ -161,15 +209,20 @@ def query_index(query: str, index: list[IndexedPost], limit: int = DEFAULT_LIMIT
     if not query_tokens:
         return []
 
-    scored = [(score, indexed) for indexed in index if (score := _score_post(query_tokens, indexed)) > 0]
+    scored: list[tuple[int, bool, IndexedPost]] = []
+    for indexed in index:
+        score, used_fuzzy = _score_post(query_tokens, indexed)
+        if score > 0:
+            scored.append((score, used_fuzzy, indexed))
     scored.sort(
-        key=lambda pair: (
-            -pair[0],
-            pair[1].result.date is None,
-            -(pair[1].result.date.toordinal() if pair[1].result.date else 0),
+        key=lambda item: (
+            item[1],
+            -item[0],
+            item[2].result.date is None,
+            -(item[2].result.date.toordinal() if item[2].result.date else 0),
         ),
     )
-    return [indexed.result for _, indexed in scored[:limit]]
+    return [indexed.result for _, _, indexed in scored[:limit]]
 
 
 def search_posts(query: str, posts: list[Post], limit: int = DEFAULT_LIMIT) -> list[SearchResult]:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -272,3 +272,22 @@ class TestBodyMarkdownStripping:
         posts = [_post("t", title="The https survival guide", description="all about png files")]
         assert len(search_posts("https", posts)) == 1
         assert len(search_posts("png", posts)) == 1
+
+
+class TestFuzzyIsPureFallback:
+    def test_fuzzy_adds_nothing_when_token_has_real_match(self):
+        """A token with an exact match anywhere must not collect fuzzy points
+        from other fields, so real-match posts tie on score and date decides."""
+        older_with_fuzzy_body = _post(
+            "older",
+            title="Gumbo recipe",
+            content="a gumbz appears here",
+            date=datetime.date(2026, 1, 1),
+        )
+        newer_plain = _post(
+            "newer",
+            title="Gumbo stories",
+            date=datetime.date(2026, 2, 1),
+        )
+        results = search_posts("gumbo", [older_with_fuzzy_body, newer_plain])
+        assert [r.url for r in results] == ["/posts/newer", "/posts/older"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -86,8 +86,71 @@ class TestPrefixMatching:
         assert len(search_posts("pyth", posts)) == 1
 
     def test_mid_word_substring_does_not_match(self):
+        # "frig" sits inside "refrigerator" but is neither a prefix of it
+        # nor within the fuzzy ratio threshold (0.5), so it must not match.
+        posts = [_post("fridge-post", title="Refrigerator Repair")]
+        assert search_posts("frig", posts) == []
+
+
+class TestFuzzyMatching:
+    def test_single_char_typo_matches(self):
+        posts = [_post("gumbo-post", title="Gumbo Recipe")]
+        results = search_posts("gumob", posts)
+        assert [r.url for r in results] == ["/posts/gumbo-post"]
+
+    def test_missing_char_typo_matches(self):
+        posts = [_post("space-post", title="Intergalactic Travel")]
+        assert len(search_posts("intergalatic", posts)) == 1
+
+    def test_near_prefix_typo_matches_via_fuzzy(self):
+        # "ython" is not a prefix of "python" but is one edit away
+        # (ratio 0.909), so the fuzzy tier picks it up.
         posts = [_post("python-post", title="Python Tips")]
-        assert search_posts("ython", posts) == []
+        assert len(search_posts("ython", posts)) == 1
+
+    def test_ratio_exactly_at_threshold_matches(self):
+        # ratio("gumbz", "gumbo") == 0.8, the inclusive threshold.
+        posts = [_post("gumbo-post", title="Gumbo Recipe")]
+        assert len(search_posts("gumbz", posts)) == 1
+
+    def test_ratio_below_threshold_does_not_match(self):
+        # ratio("gumb", "gump") == 0.75, just under the threshold.
+        posts = [_post("gump-post", title="Gump Tales")]
+        assert search_posts("gumb", posts) == []
+
+    def test_short_query_token_never_fuzzy_matches(self):
+        # ratio("tew", "stew") == 0.857, above the threshold, but tokens
+        # under 4 chars are excluded from the fuzzy tier.
+        posts = [_post("stew-post", title="Stew Night")]
+        assert search_posts("tew", posts) == []
+
+    def test_fuzzy_ranks_below_exact_and_prefix_in_same_field(self):
+        posts = [
+            _post("fuzzy-hit", title="Gumbz Files"),
+            _post("prefix-hit", title="Gumbology Studies"),
+            _post("exact-hit", title="Gumbo Recipe"),
+        ]
+        results = search_posts("gumbo", posts)
+        assert [r.url for r in results] == [
+            "/posts/exact-hit",
+            "/posts/prefix-hit",
+            "/posts/fuzzy-hit",
+        ]
+
+    def test_fuzzy_never_outranks_real_match_across_fields(self):
+        # A fuzzy title hit carries more weight than an exact body hit,
+        # but posts needing fuzzy still sort behind real matches.
+        posts = [
+            _post("fuzzy-title", title="Gumbz"),
+            _post("exact-body", title="Cooking Notes", content="gumbo simmering all day"),
+        ]
+        results = search_posts("gumbo", posts)
+        assert [r.url for r in results] == ["/posts/exact-body", "/posts/fuzzy-title"]
+
+    def test_fuzzy_token_counts_toward_and_semantics(self):
+        posts = [_post("gumbo-post", title="Gumbo Recipe", content="cooking at midnight")]
+        assert len(search_posts("gumob midnight", posts)) == 1
+        assert search_posts("gumob zeppelin", posts) == []
 
 
 class TestMultiTokenAnd:


### PR DESCRIPTION
Closes #103

Adds a third, lowest-ranked match tier to the search scorer using stdlib difflib: query tokens of length >= 4 that fail exact and prefix match against field tokens at SequenceMatcher ratio >= 0.8.

Ranking guarantee: weights alone cannot keep every fuzzy hit below every real hit across fields (a fuzzy title weight would outscore an exact body weight), so posts that needed any fuzzy match sort behind posts matched entirely by exact/prefix; the third-tier weights only order posts within the fuzzy class. AND semantics, the /search contract, and the index format are unchanged.

Performance: fuzzy only runs for tokens that already failed exact and prefix, with a real_quick_ratio pre-filter; measured ~0.6 ms per post worst case against a 500-token body vocabulary. rapidfuzz remains the escape hatch per the issue if content scale grows.

Tests: 9 new cases covering the 0.8 boundary, short-token exclusion, typo recall (gumob, intergalatic), in-field tier ordering, cross-field never-outrank, and AND semantics. One existing test repointed: its old probe token now legitimately fuzzy-matches, kept as a positive fuzzy case.

Live-verified: /search?q=gumob and /search?q=intergalatic both return the gumbo post; exact queries unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)