### PR TITLE
feat(themes): add social share buttons to posts

### DIFF
--- a/.claude/skills/theme-creator/references/filters.md
+++ b/.claude/skills/theme-creator/references/filters.md
@@ -5,5 +5,8 @@
 | `format_date` | `format_date(value, fmt="%B %d, %Y")` | Formats a date — e.g. `{{ post.date \| format_date }}` |
 | `accent_first_word` | `accent_first_word(value)` | Wraps first word in `<span class="accent">` |
 | `accent_last_word` | `accent_last_word(value)` | Wraps last word in `<span class="accent">` |
+| `share_urls` | `share_urls(post, canonical_url)` | `(platform, url)` share link pairs; empty list when `canonical_url` is unset. Usage: `{% for platform, url in post \| share_urls(canonical_url) %}` |
 
 All accent filters return `Markup` (safe HTML).
+
+Themes get share buttons by including the shared partial (falls back to the default theme): `{% include "_share.html" %}`. Set `share_label` beforehand to override the "Share" label.

--- a/src/squishmark/services/theme/filters.py
+++ b/src/squishmark/services/theme/filters.py
@@ -1,6 +1,7 @@
 """Custom Jinja2 filters for SquishMark templates."""
 
 from typing import Any
+from urllib.parse import quote
 
 from jinja2 import Environment
 from markupsafe import Markup
@@ -35,8 +36,31 @@ def accent_last_word(value: str) -> Markup:
     return Markup(f'{words[0]} <span class="accent">{words[1]}</span>')
 
 
+def share_urls(post: Any, canonical_url: str | None) -> list[tuple[str, str]]:
+    """Build (platform, share_url) pairs for a post.
+
+    Takes the absolute post URL (canonical_url from the render context) and
+    returns direct share links with the URL and title percent-encoded.
+    Returns an empty list when canonical_url is falsy (site.url unset) so
+    templates can hide the share section entirely.
+    """
+    if not canonical_url:
+        return []
+    url = quote(canonical_url, safe="")
+    title = quote(getattr(post, "title", "") or "", safe="")
+    return [
+        ("Twitter/X", f"https://twitter.com/intent/tweet?url={url}&text={title}"),
+        ("LinkedIn", f"https://www.linkedin.com/sharing/share-offsite/?url={url}"),
+        ("Facebook", f"https://www.facebook.com/sharer/sharer.php?u={url}"),
+        ("Reddit", f"https://reddit.com/submit?url={url}&title={title}"),
+        ("Hacker News", f"https://news.ycombinator.com/submitlink?u={url}&t={title}"),
+        ("Email", f"mailto:?subject={title}&body={url}"),
+    ]
+
+
 def register_filters(env: Environment) -> None:
     """Register all custom filters on a Jinja2 environment."""
     env.filters["format_date"] = format_date
     env.filters["accent_first_word"] = accent_first_word
     env.filters["accent_last_word"] = accent_last_word
+    env.filters["share_urls"] = share_urls

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -209,22 +209,3 @@ class TestBodyMarkdownStripping:
         posts = [_post("t", title="The https survival guide", description="all about png files")]
         assert len(search_posts("https", posts)) == 1
         assert len(search_posts("png", posts)) == 1
-
-
-class TestFuzzyIsPureFallback:
-    def test_fuzzy_adds_nothing_when_token_has_real_match(self):
-        """A token with an exact match anywhere must not collect fuzzy points
-        from other fields, so real-match posts tie on score and date decides."""
-        older_with_fuzzy_body = _post(
-            "older",
-            title="Gumbo recipe",
-            content="a gumbz appears here",
-            date=datetime.date(2026, 1, 1),
-        )
-        newer_plain = _post(
-            "newer",
-            title="Gumbo stories",
-            date=datetime.date(2026, 2, 1),
-        )
-        results = search_posts("gumbo", [older_with_fuzzy_body, newer_plain])
-        assert [r.url for r in results] == ["/posts/newer", "/posts/older"]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -209,3 +209,22 @@ class TestBodyMarkdownStripping:
         posts = [_post("t", title="The https survival guide", description="all about png files")]
         assert len(search_posts("https", posts)) == 1
         assert len(search_posts("png", posts)) == 1
+
+
+class TestFuzzyIsPureFallback:
+    def test_fuzzy_adds_nothing_when_token_has_real_match(self):
+        """A token with an exact match anywhere must not collect fuzzy points
+        from other fields, so real-match posts tie on score and date decides."""
+        older_with_fuzzy_body = _post(
+            "older",
+            title="Gumbo recipe",
+            content="a gumbz appears here",
+            date=datetime.date(2026, 1, 1),
+        )
+        newer_plain = _post(
+            "newer",
+            title="Gumbo stories",
+            date=datetime.date(2026, 2, 1),
+        )
+        results = search_posts("gumbo", [older_with_fuzzy_body, newer_plain])
+        assert [r.url for r in results] == ["/posts/newer", "/posts/older"]

--- a/tests/test_share_urls.py
+++ b/tests/test_share_urls.py
@@ -1,0 +1,103 @@
+"""Tests for the share_urls filter and share button rendering."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from jinja2 import Environment
+
+from squishmark.models.content import Config, Post
+from squishmark.services.cache import Cache
+from squishmark.services.container import Services
+from squishmark.services.theme.engine import ThemeEngine
+from squishmark.services.theme.filters import register_filters, share_urls
+
+THEMES_PATH = Path(__file__).parent.parent / "themes"
+
+CANONICAL = "https://example.com/posts/hello"
+
+
+def _post(title: str = "Hello World") -> Post:
+    return Post(slug="hello", title=title)
+
+
+class TestShareUrls:
+    def test_returns_empty_list_when_canonical_url_is_none(self):
+        assert share_urls(_post(), None) == []
+
+    def test_returns_empty_list_when_canonical_url_is_empty(self):
+        assert share_urls(_post(), "") == []
+
+    def test_returns_all_platforms_in_order(self):
+        platforms = [platform for platform, _ in share_urls(_post(), CANONICAL)]
+        assert platforms == ["Twitter/X", "LinkedIn", "Facebook", "Reddit", "Hacker News", "Email"]
+
+    def test_url_is_fully_percent_encoded(self):
+        results = dict(share_urls(_post(), CANONICAL))
+        encoded = "https%3A%2F%2Fexample.com%2Fposts%2Fhello"
+        assert results["Twitter/X"] == f"https://twitter.com/intent/tweet?url={encoded}&text=Hello%20World"
+        assert results["LinkedIn"] == f"https://www.linkedin.com/sharing/share-offsite/?url={encoded}"
+        assert results["Facebook"] == f"https://www.facebook.com/sharer/sharer.php?u={encoded}"
+        assert results["Reddit"] == f"https://reddit.com/submit?url={encoded}&title=Hello%20World"
+        assert results["Hacker News"] == f"https://news.ycombinator.com/submitlink?u={encoded}&t=Hello%20World"
+        assert results["Email"] == f"mailto:?subject=Hello%20World&body={encoded}"
+
+    def test_ampersand_in_title_is_encoded(self):
+        results = dict(share_urls(_post("Cats & Dogs"), CANONICAL))
+        assert "Cats%20%26%20Dogs" in results["Reddit"]
+        assert "&title=Cats" in results["Reddit"]
+
+    def test_unicode_title_is_utf8_percent_encoded(self):
+        results = dict(share_urls(_post("Héllo Wörld"), CANONICAL))
+        assert "H%C3%A9llo%20W%C3%B6rld" in results["Twitter/X"]
+
+    def test_question_mark_and_equals_in_title_are_encoded(self):
+        results = dict(share_urls(_post("what=up?"), CANONICAL))
+        assert "what%3Dup%3F" in results["Email"]
+
+    def test_query_string_in_url_is_encoded(self):
+        results = dict(share_urls(_post(), "https://example.com/posts/hi?a=1&b=2"))
+        assert "%3Fa%3D1%26b%3D2" in results["Facebook"]
+
+    def test_object_without_title_yields_empty_title(self):
+        results = dict(share_urls(object(), CANONICAL))
+        assert results["Email"].startswith("mailto:?subject=&body=")
+
+    def test_filter_is_registered(self):
+        env = Environment()
+        register_filters(env)
+        assert env.filters["share_urls"] is share_urls
+
+
+def _make_engine() -> ThemeEngine:
+    github_service = MagicMock()
+    github_service.list_directory = AsyncMock(return_value=[])
+    github_service.get_config = AsyncMock(return_value={})
+    services = Services(settings=MagicMock(), cache=Cache(ttl_seconds=0), github=github_service)
+    engine = ThemeEngine(services, themes_path=THEMES_PATH)
+    engine.favicon_detector.detect = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    return engine
+
+
+class TestShareSectionRendering:
+    """Share buttons render on post pages across all bundled themes."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("theme", ["default", "blue-tech", "terminal"])
+    async def test_share_section_rendered_when_site_url_set(self, theme: str):
+        engine = _make_engine()
+        config = Config.from_dict({"site": {"title": "Test", "url": "https://example.com"}})
+        html = await engine.render_post(config, _post(), theme_override=theme)
+        assert 'class="post-share"' in html
+        assert 'rel="noopener noreferrer"' in html
+        assert "https%3A%2F%2Fexample.com%2Fposts%2Fhello" in html
+        assert 'class="share-btn share-copy"' in html
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("theme", ["default", "blue-tech", "terminal"])
+    async def test_share_section_hidden_when_site_url_unset(self, theme: str):
+        engine = _make_engine()
+        config = Config.from_dict({"site": {"title": "Test"}})
+        html = await engine.render_post(config, _post(), theme_override=theme)
+        assert "post-share" not in html
+        assert "share-btn" not in html

--- a/themes/blue-tech/post.html
+++ b/themes/blue-tech/post.html
@@ -81,6 +81,7 @@
             {% endif %}
         </nav>
         {% endif %}
+        {% include "_share.html" %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -814,6 +814,59 @@ img {
     color: var(--color-accent);
 }
 
+/* Social share buttons */
+.post-share {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.post-share-label {
+    color: var(--color-text-subtle);
+    font-size: 0.875rem;
+    margin-right: 0.25rem;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-card);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.share-btn:hover {
+    color: var(--color-accent-light);
+    border-color: var(--color-border-hover);
+}
+
+.share-btn svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.share-copy .icon-check {
+    display: none;
+}
+
+.share-copy.copied .icon-link {
+    display: none;
+}
+
+.share-copy.copied .icon-check {
+    display: block;
+    color: var(--color-accent-light);
+}
+
 /* ============================================
    Error Page
    ============================================ */

--- a/themes/default/_share.html
+++ b/themes/default/_share.html
@@ -1,0 +1,53 @@
+{# Social share buttons. Hidden entirely when site.url is not configured. #}
+{% if canonical_url %}
+{% set share_icons = {
+    "Twitter/X": '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>',
+    "LinkedIn": '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>',
+    "Facebook": '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>',
+    "Reddit": '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z"/></svg>',
+    "Hacker News": '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M0 24V0h24v24H0zM6.951 5.896l4.112 7.708v5.064h1.583v-4.972l4.148-7.799h-1.749l-2.457 4.875c-.372.745-.688 1.434-.688 1.434s-.297-.708-.651-1.434L8.831 5.896h-1.88z"/></svg>',
+    "Email": '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 6L2 7"/></svg>',
+} %}
+<div class="post-share">
+    <span class="post-share-label">{{ share_label | default("Share") }}</span>
+    {% for platform, url in post | share_urls(canonical_url) %}
+    {% if url.startswith("mailto:") %}
+    <a class="share-btn" href="{{ url }}" aria-label="Share via {{ platform }}" title="Share via {{ platform }}">{{ share_icons[platform] | safe }}</a>
+    {% else %}
+    <a class="share-btn" href="{{ url }}" target="_blank" rel="noopener noreferrer" aria-label="Share on {{ platform }}" title="Share on {{ platform }}">{{ share_icons[platform] | safe }}</a>
+    {% endif %}
+    {% endfor %}
+    <button type="button" class="share-btn share-copy" data-share-url="{{ canonical_url }}" aria-label="Copy link" title="Copy link">
+        <svg class="icon-link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+        <svg class="icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+    </button>
+</div>
+<script>
+(function () {
+    var btn = document.querySelector(".share-copy");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+        var url = btn.getAttribute("data-share-url");
+        var done = function () {
+            btn.classList.add("copied");
+            setTimeout(function () { btn.classList.remove("copied"); }, 1500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(done);
+        } else {
+            /* Fallback for non-secure contexts and older browsers */
+            var ta = document.createElement("textarea");
+            ta.value = url;
+            ta.setAttribute("readonly", "");
+            ta.style.position = "absolute";
+            ta.style.left = "-9999px";
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand("copy");
+            document.body.removeChild(ta);
+            done();
+        }
+    });
+})();
+</script>
+{% endif %}

--- a/themes/default/_share.html
+++ b/themes/default/_share.html
@@ -32,10 +32,9 @@
             btn.classList.add("copied");
             setTimeout(function () { btn.classList.remove("copied"); }, 1500);
         };
-        if (navigator.clipboard && navigator.clipboard.writeText) {
-            navigator.clipboard.writeText(url).then(done);
-        } else {
-            /* Fallback for non-secure contexts and older browsers */
+        /* Fallback for non-secure contexts, older browsers, and clipboard
+           permission rejections */
+        var fallback = function () {
             var ta = document.createElement("textarea");
             ta.value = url;
             ta.setAttribute("readonly", "");
@@ -46,6 +45,11 @@
             document.execCommand("copy");
             document.body.removeChild(ta);
             done();
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(done).catch(fallback);
+        } else {
+            fallback();
         }
     });
 })();

--- a/themes/default/post.html
+++ b/themes/default/post.html
@@ -84,6 +84,7 @@
             {% endif %}
         </nav>
         {% endif %}
+        {% include "_share.html" %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/default/static/style.css
+++ b/themes/default/static/style.css
@@ -857,6 +857,59 @@ a:hover {
     color: var(--color-accent);
 }
 
+/* Social share buttons */
+.post-share {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: var(--spacing-unit);
+}
+
+.post-share-label {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+    margin-right: 0.25rem;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    background: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.share-btn:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent-subtle-border);
+}
+
+.share-btn svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.share-copy .icon-check {
+    display: none;
+}
+
+.share-copy.copied .icon-link {
+    display: none;
+}
+
+.share-copy.copied .icon-check {
+    display: block;
+    color: var(--color-accent);
+}
+
 /* Notes */
 .notes {
     background-color: var(--color-note-bg);

--- a/themes/terminal/post.html
+++ b/themes/terminal/post.html
@@ -80,6 +80,8 @@
             {% endif %}
         </nav>
         {% endif %}
+        {% set share_label = "// share" %}
+        {% include "_share.html" %}
         <a href="/posts" class="back-link">&larr; Back to posts</a>
     </footer>
 </article>

--- a/themes/terminal/static/css/style.css
+++ b/themes/terminal/static/css/style.css
@@ -749,6 +749,60 @@ img {
     color: var(--color-blue);
 }
 
+/* Social share buttons */
+.post-share {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.post-share-label {
+    font-family: var(--font-mono);
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    margin-right: 0.25rem;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    transition: color var(--transition), border-color var(--transition);
+}
+
+.share-btn:hover {
+    color: var(--color-green);
+    border-color: var(--color-border-hover);
+}
+
+.share-btn svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.share-copy .icon-check {
+    display: none;
+}
+
+.share-copy.copied .icon-link {
+    display: none;
+}
+
+.share-copy.copied .icon-check {
+    display: block;
+    color: var(--color-green);
+}
+
 /* ============================================
    Error Page
    ============================================ */


### PR DESCRIPTION
Closes #12

Share buttons on post pages across all three bundled themes: Twitter/X, LinkedIn, Facebook, Reddit, Hacker News, Email, plus a copy-link button.

- Shared share_urls Jinja filter builds the links from the existing canonical_url with full percent-encoding (unicode titles included); returns empty when site.url is unset so the section hides entirely
- One shared partial (themes/default/_share.html) with inline SVG icons and a few lines of clipboard JS (navigator.clipboard with an execCommand fallback); blue-tech and terminal include it via the loader's default-theme fallback, zero duplication, content repos can override it
- Direct share URLs only, no tracking scripts or widgets; rel="noopener noreferrer" on external links; per-theme CSS matching each theme's look
- 16 tests: platform set and order, encoding edge cases, hidden case, and render tests across all three themes

Browser-verified on all three themes: share row renders in each theme's style, copy button shows its feedback state, links are correctly encoded, and the section is absent when site.url is not configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)