### PR TITLE
feat(themes): split theme homepages from the posts listing

### DIFF
--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -5,13 +5,13 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from fastapi import FastAPI, HTTPException, Request, WebSocket
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from starlette.middleware.sessions import SessionMiddleware
 
 from squishmark.config import get_settings
 from squishmark.models.content import Config
 from squishmark.models.db import close_db, init_db
-from squishmark.routers import admin, archive, assets, auth, feed, pages, posts, search, seo, tags, webhooks
+from squishmark.routers import admin, archive, assets, auth, feed, home, pages, posts, search, seo, tags, webhooks
 from squishmark.services.analytics_middleware import register_analytics_middleware
 from squishmark.services.container import build_services
 from squishmark.services.livereload import LiveReloadService
@@ -142,12 +142,6 @@ def create_app() -> FastAPI:
         """Health check endpoint for container orchestration."""
         return {"status": "healthy"}
 
-    # Home page - redirect to /posts
-    @app.get("/", response_class=HTMLResponse)
-    async def index(request: Request) -> RedirectResponse:
-        """Redirect root to posts listing."""
-        return RedirectResponse(url="/posts", status_code=302)
-
     # LiveReload WebSocket endpoint and middleware (debug mode only)
     if settings.debug:
         from squishmark.services.livereload import LiveReloadMiddleware
@@ -167,6 +161,7 @@ def create_app() -> FastAPI:
     app.include_router(webhooks.router)
     app.include_router(feed.router)
     app.include_router(seo.router)
+    app.include_router(home.router)  # GET / (theme homepage or redirect to /posts)
     app.include_router(search.router)
     app.include_router(assets.router)
     app.include_router(posts.router)

--- a/src/squishmark/routers/home.py
+++ b/src/squishmark/routers/home.py
@@ -1,0 +1,48 @@
+"""Route for the site homepage at ``/``."""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from squishmark.dependencies import SiteContextDep, ThemeEngineDep, is_admin
+from squishmark.services.content import get_cached_posts, get_featured_posts
+
+router = APIRouter(tags=["home"])
+
+# Number of most-recent posts exposed to home.html as latest_posts.
+LATEST_POSTS_LIMIT = 5
+
+
+@router.get("/", response_class=HTMLResponse, response_model=None)
+async def home(
+    request: Request,
+    context: SiteContextDep,
+    theme_engine: ThemeEngineDep,
+) -> HTMLResponse | RedirectResponse:
+    """Render the theme homepage, or redirect to /posts when none resolves.
+
+    A theme opts into a distinct landing page by shipping ``home.html`` (or a
+    content-repo override). Themes without one (including default) keep the
+    historical 302 to the posts listing.
+    """
+    config = context.config
+    theme_name = config.theme.name
+
+    # The default-theme fallback is excluded, so default (which ships no
+    # home.html) still redirects.
+    if not theme_engine.has_template("home.html", theme_name):
+        return RedirectResponse(url="/posts", status_code=302)
+
+    # Draft-gated like /posts: admins see drafts, anonymous visitors do not.
+    include_drafts = is_admin(request)
+    all_posts = await get_cached_posts(context.services, include_drafts=include_drafts)
+    latest_posts = all_posts[:LATEST_POSTS_LIMIT]
+    featured = get_featured_posts(all_posts, config.site)
+
+    html = await theme_engine.render(
+        "home.html",
+        config,
+        latest_posts=latest_posts,
+        featured_posts=featured,
+        canonical_url=theme_engine.build_canonical_url(config, "/"),
+    )
+    return HTMLResponse(content=html)

--- a/src/squishmark/routers/seo.py
+++ b/src/squishmark/routers/seo.py
@@ -6,7 +6,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from fastapi import APIRouter
 from fastapi.responses import Response
 
-from squishmark.dependencies import ServicesDep
+from squishmark.dependencies import ServicesDep, ThemeEngineDep
 from squishmark.models.content import Config, Page, Post
 from squishmark.services.content import get_cached_pages, get_cached_posts
 
@@ -25,14 +25,25 @@ def _add_url(urlset: Element, loc: str, lastmod: datetime.date | None = None) ->
         SubElement(url_el, "lastmod").text = lastmod.isoformat()
 
 
-def _build_sitemap(config: Config, posts: list[Post], pages: list[Page]) -> bytes:
-    """Build a sitemap.xml from config, posts, and pages."""
+def _build_sitemap(
+    config: Config,
+    posts: list[Post],
+    pages: list[Page],
+    include_home: bool = True,
+) -> bytes:
+    """Build a sitemap.xml from config, posts, and pages.
+
+    ``/`` is listed only when ``include_home`` is set (the active theme
+    resolves a homepage); otherwise ``/`` redirects to ``/posts`` and is
+    omitted.
+    """
     site_url = config.site.url.rstrip("/") if config.site.url else ""
     newest_post_date = posts[0].date if posts else None
 
     urlset = Element("urlset", xmlns=SITEMAP_NS)
 
-    _add_url(urlset, f"{site_url}/", newest_post_date)
+    if include_home:
+        _add_url(urlset, f"{site_url}/", newest_post_date)
     _add_url(urlset, f"{site_url}/posts", newest_post_date)
 
     for post in posts:
@@ -67,7 +78,7 @@ def _build_robots_txt(config: Config) -> str:
 
 
 @router.get("/sitemap.xml")
-async def sitemap_xml(services: ServicesDep) -> Response:
+async def sitemap_xml(services: ServicesDep, theme_engine: ThemeEngineDep) -> Response:
     """Serve the XML sitemap."""
     cache = services.cache
 
@@ -81,7 +92,8 @@ async def sitemap_xml(services: ServicesDep) -> Response:
     posts = await get_cached_posts(services, include_drafts=False)
     pages = await get_cached_pages(services, include_hidden=False)
 
-    xml_bytes = _build_sitemap(config, posts, pages)
+    include_home = theme_engine.has_template("home.html", config.theme.name)
+    xml_bytes = _build_sitemap(config, posts, pages, include_home=include_home)
     await cache.set(SITEMAP_CACHE_KEY, xml_bytes)
     return Response(content=xml_bytes, media_type="application/xml; charset=utf-8")
 

--- a/src/squishmark/services/theme/engine.py
+++ b/src/squishmark/services/theme/engine.py
@@ -128,6 +128,15 @@ class ThemeEngine:
         # Unknown theme or user overrode the style -- use dynamic route
         return "/pygments.css"
 
+    def has_template(self, name: str, theme_name: str) -> bool:
+        """True when the active theme resolves ``name`` from its own directory
+        or a content-repo override.
+
+        The default-theme fallback is excluded, so a template shipped only by
+        the default theme does not leak onto every other theme.
+        """
+        return self.loader.has_theme_template(theme_name, name)
+
     async def render(
         self,
         template_name: str,

--- a/src/squishmark/services/theme/filters.py
+++ b/src/squishmark/services/theme/filters.py
@@ -1,5 +1,6 @@
 """Custom Jinja2 filters for SquishMark templates."""
 
+import re
 from typing import Any
 from urllib.parse import quote
 
@@ -17,12 +18,24 @@ def format_date(value: Any, fmt: str = "%B %d, %Y") -> str:
 
 
 def accent_first_word(value: str) -> Markup:
-    """Wrap the first word in an accent span for styling."""
+    """Wrap the first word in an accent span for styling.
+
+    Multi-word titles accent the first whitespace-delimited word. A single-word
+    CamelCase title (e.g. ``SquishMark``) is split on its last interior
+    uppercase boundary so it renders two-tone (``Squish`` accented, ``Mark``
+    plain), matching the navbar logo; a single lowercase word falls back to
+    accenting the whole word.
+    """
     if not value:
         return Markup("")
     words = value.split(" ", 1)
     if len(words) == 1:
-        return Markup(f'<span class="accent">{words[0]}</span>')
+        word = words[0]
+        interior_caps = [m.start() for m in re.finditer(r"[A-Z]", word) if m.start() > 0]
+        if interior_caps:
+            split = interior_caps[-1]
+            return Markup(f'<span class="accent">{word[:split]}</span>{word[split:]}')
+        return Markup(f'<span class="accent">{word}</span>')
     return Markup(f'<span class="accent">{words[0]}</span> {words[1]}')
 
 

--- a/src/squishmark/services/theme/filters.py
+++ b/src/squishmark/services/theme/filters.py
@@ -5,7 +5,7 @@ from typing import Any
 from urllib.parse import quote
 
 from jinja2 import Environment
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 
 def format_date(value: Any, fmt: str = "%B %d, %Y") -> str:
@@ -34,9 +34,9 @@ def accent_first_word(value: str) -> Markup:
         interior_caps = [m.start() for m in re.finditer(r"[A-Z]", word) if m.start() > 0]
         if interior_caps:
             split = interior_caps[-1]
-            return Markup(f'<span class="accent">{word[:split]}</span>{word[split:]}')
-        return Markup(f'<span class="accent">{word}</span>')
-    return Markup(f'<span class="accent">{words[0]}</span> {words[1]}')
+            return Markup(f'<span class="accent">{escape(word[:split])}</span>{escape(word[split:])}')
+        return Markup(f'<span class="accent">{escape(word)}</span>')
+    return Markup(f'<span class="accent">{escape(words[0])}</span> {escape(words[1])}')
 
 
 def accent_last_word(value: str) -> Markup:
@@ -45,8 +45,8 @@ def accent_last_word(value: str) -> Markup:
         return Markup("")
     words = value.rsplit(" ", 1)
     if len(words) == 1:
-        return Markup(f'<span class="accent">{words[0]}</span>')
-    return Markup(f'{words[0]} <span class="accent">{words[1]}</span>')
+        return Markup(f'<span class="accent">{escape(words[0])}</span>')
+    return Markup(f'{escape(words[0])} <span class="accent">{escape(words[1])}</span>')
 
 
 def share_urls(post: Any, canonical_url: str | None) -> list[tuple[str, str]]:

--- a/src/squishmark/services/theme/loader.py
+++ b/src/squishmark/services/theme/loader.py
@@ -66,6 +66,21 @@ class AsyncHybridLoader(BaseLoader):
         """Clear the template cache."""
         self._template_cache.clear()
 
+    def has_theme_template(self, theme: str, name: str) -> bool:
+        """True when ``theme``'s own directory or a content-repo override
+        provides ``name``.
+
+        The default-theme fallback is deliberately excluded: a template that
+        only exists in the default theme is not reported for other themes.
+        When ``theme`` is the default theme, its own directory is checked as
+        normal (that is the active theme's file, not a fallback).
+        """
+        if _is_unsafe(theme) or _is_unsafe(name):
+            return False
+        if name in self._template_cache:
+            return True
+        return (self.themes_path / theme / name).is_file()
+
     def get_source(self, environment: Environment, template: str) -> tuple[str, str | None, Any]:
         """Load a template from cache, requested theme, or default theme."""
         theme, name = split_theme(template, self.default_theme)

--- a/tests/test_accent_filters.py
+++ b/tests/test_accent_filters.py
@@ -22,3 +22,10 @@ def test_space_rule_wins_over_capitals():
     """A spaced title splits on the space only; CamelCase in the first word
     is left intact (the rules are mutually exclusive)."""
     assert str(accent_first_word("SquishMark Blog")) == '<span class="accent">SquishMark</span> Blog'
+
+
+def test_html_in_title_is_escaped():
+    """Markup bypasses autoescaping, so the filter must escape the parts."""
+    result = str(accent_first_word("<script>x</script> Blog"))
+    assert "<script>" not in result
+    assert "&lt;script&gt;" in result

--- a/tests/test_accent_filters.py
+++ b/tests/test_accent_filters.py
@@ -16,3 +16,9 @@ class TestAccentFirstWord:
 
     def test_empty_string_returns_empty_markup(self):
         assert str(accent_first_word("")) == ""
+
+
+def test_space_rule_wins_over_capitals():
+    """A spaced title splits on the space only; CamelCase in the first word
+    is left intact (the rules are mutually exclusive)."""
+    assert str(accent_first_word("SquishMark Blog")) == '<span class="accent">SquishMark</span> Blog'

--- a/tests/test_accent_filters.py
+++ b/tests/test_accent_filters.py
@@ -1,0 +1,18 @@
+"""Tests for the accent_first_word Jinja2 filter."""
+
+from squishmark.services.theme.filters import accent_first_word
+
+
+class TestAccentFirstWord:
+    def test_single_word_camelcase_splits_on_last_interior_cap(self):
+        # "SquishMark" -> accent "Squish" + plain "Mark" (two-tone like the navbar).
+        assert str(accent_first_word("SquishMark")) == '<span class="accent">Squish</span>Mark'
+
+    def test_single_word_lowercase_accents_whole_word(self):
+        assert str(accent_first_word("squishmark")) == '<span class="accent">squishmark</span>'
+
+    def test_multi_word_title_unchanged(self):
+        assert str(accent_first_word("My Blog")) == '<span class="accent">My</span> Blog'
+
+    def test_empty_string_returns_empty_markup(self):
+        assert str(accent_first_word("")) == ""

--- a/tests/test_routes_home.py
+++ b/tests/test_routes_home.py
@@ -1,0 +1,108 @@
+"""Integration tests for the theme homepage at / (issue #32).
+
+home.html is injected through the content-repo custom-template path
+(``theme/home.html``), so no bundled theme ships one. The template must be
+present before the lifespan loads custom templates, so these tests build their
+own app rather than using the shared ``client`` fixture.
+"""
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.main import create_app
+from tests.conftest import FakeGitHubService
+
+pytestmark = pytest.mark.integration
+
+# Renders the context contract home.html templates rely on, in a parseable form.
+HOME_TEMPLATE = (
+    "HOME"
+    "|latest:{% for p in latest_posts %}{{ p.title }};{% endfor %}"
+    "|featured:{% for p in featured_posts %}{{ p.title }};{% endfor %}"
+    "|canonical:{{ canonical_url }}"
+)
+
+
+@contextmanager
+def home_client(fake_github: FakeGitHubService, *, admin: bool = False) -> Iterator[TestClient]:
+    """Yield a client whose content repo ships a home.html override."""
+    fake_github.files["theme/home.html"] = HOME_TEMPLATE
+    app = create_app()
+
+    if admin:
+        from fastapi import Request
+
+        @app.get("/_test/seed-session")
+        async def _seed(request: Request) -> dict:
+            request.session["user"] = {"login": "admin-user"}
+            return {"ok": True}
+
+    base_url = "https://testserver" if admin else "http://testserver"
+    with TestClient(app, base_url=base_url) as client:
+        if admin:
+            resp = client.get("/_test/seed-session")
+            assert resp.status_code == 200, resp.text
+        yield client
+
+
+def _section(body: str, start: str, end: str) -> str:
+    """Extract the text between two markers in the rendered homepage."""
+    return body.split(start)[1].split(end)[0]
+
+
+def test_root_redirects_when_theme_has_no_home(client: TestClient) -> None:
+    """Default theme ships no home.html, so / keeps the historical redirect."""
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/posts"
+
+
+def test_root_renders_home_when_theme_has_home(fake_github: FakeGitHubService) -> None:
+    with home_client(fake_github) as c:
+        resp = c.get("/")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "HOME" in resp.text
+
+
+def test_home_latest_posts_newest_first_excludes_drafts(fake_github: FakeGitHubService) -> None:
+    with home_client(fake_github) as c:
+        resp = c.get("/")
+    latest = _section(resp.text, "latest:", "|featured")
+    assert latest == "Post Five;Post Four;Post Three;Post Two;Post One;"
+    assert "Secret Draft" not in latest
+
+
+def test_home_latest_includes_drafts_for_admin(fake_github: FakeGitHubService) -> None:
+    with home_client(fake_github, admin=True) as c:
+        resp = c.get("/")
+    latest = _section(resp.text, "latest:", "|featured")
+    # The draft is the newest post, so it heads the admin latest list, and the
+    # five-item cap drops the oldest published post.
+    assert latest == "Secret Draft;Post Five;Post Four;Post Three;Post Two;"
+
+
+def test_home_featured_populated(fake_github: FakeGitHubService) -> None:
+    fake_github.files["posts/2026-02-01-featured-post.md"] = (
+        "---\ntitle: Featured Post\nfeatured: true\n---\n\n# Featured Post\n\nBody.\n"
+    )
+    with home_client(fake_github) as c:
+        resp = c.get("/")
+    featured = _section(resp.text, "featured:", "|canonical")
+    assert featured == "Featured Post;"
+
+
+def test_home_featured_empty_without_featured_posts(fake_github: FakeGitHubService) -> None:
+    with home_client(fake_github) as c:
+        resp = c.get("/")
+    featured = _section(resp.text, "featured:", "|canonical")
+    assert featured == ""
+
+
+def test_home_canonical_url(fake_github: FakeGitHubService) -> None:
+    with home_client(fake_github) as c:
+        resp = c.get("/")
+    assert resp.text.endswith("canonical:https://test.example.com/")

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -23,6 +23,13 @@ def _services(github: AsyncMock, cache: AsyncMock) -> Services:
     return Services(settings=MagicMock(), cache=cache, github=github)
 
 
+def _theme_engine(has_home: bool = False) -> MagicMock:
+    """A theme engine stub whose has_template reports homepage resolution."""
+    engine = MagicMock()
+    engine.has_template.return_value = has_home
+    return engine
+
+
 @pytest.fixture
 def sample_config() -> Config:
     return Config.from_dict(
@@ -146,6 +153,20 @@ class TestBuildSitemap:
         locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
         assert "https://example.com/hidden-page" not in locs
 
+    def test_homepage_included_by_default(self, sample_config, sample_posts, sample_pages):
+        xml_bytes = _build_sitemap(sample_config, sample_posts, sample_pages)
+        root = fromstring(xml_bytes)
+        locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
+        assert "https://example.com/" in locs
+
+    def test_homepage_excluded_when_include_home_false(self, sample_config, sample_posts, sample_pages):
+        xml_bytes = _build_sitemap(sample_config, sample_posts, sample_pages, include_home=False)
+        root = fromstring(xml_bytes)
+        locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
+        assert "https://example.com/" not in locs
+        # The posts listing stays regardless.
+        assert "https://example.com/posts" in locs
+
     def test_empty_content(self, sample_config):
         xml_bytes = _build_sitemap(sample_config, [], [])
         root = fromstring(xml_bytes)
@@ -220,7 +241,7 @@ class TestSitemapEndpoint:
 
         from squishmark.routers.seo import sitemap_xml
 
-        response = await sitemap_xml(_services(mock_github, mock_cache))
+        response = await sitemap_xml(_services(mock_github, mock_cache), _theme_engine())
 
         assert "application/xml" in response.media_type
 
@@ -233,9 +254,48 @@ class TestSitemapEndpoint:
 
         from squishmark.routers.seo import sitemap_xml
 
-        response = await sitemap_xml(_services(AsyncMock(), mock_cache))
+        response = await sitemap_xml(_services(AsyncMock(), mock_cache), _theme_engine())
 
         assert response.body == cached_xml
+
+    @pytest.mark.asyncio
+    async def test_homepage_included_when_theme_has_home(self):
+        mock_github = AsyncMock()
+        mock_github.get_config.return_value = {
+            "site": {"title": "Test", "url": "https://example.com"},
+        }
+        mock_github.list_directory.return_value = []
+
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
+
+        from squishmark.routers.seo import sitemap_xml
+
+        response = await sitemap_xml(_services(mock_github, mock_cache), _theme_engine(has_home=True))
+
+        root = fromstring(response.body)
+        locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
+        assert "https://example.com/" in locs
+
+    @pytest.mark.asyncio
+    async def test_homepage_excluded_when_theme_has_no_home(self):
+        mock_github = AsyncMock()
+        mock_github.get_config.return_value = {
+            "site": {"title": "Test", "url": "https://example.com"},
+        }
+        mock_github.list_directory.return_value = []
+
+        mock_cache = AsyncMock()
+        mock_cache.get.return_value = None
+
+        from squishmark.routers.seo import sitemap_xml
+
+        response = await sitemap_xml(_services(mock_github, mock_cache), _theme_engine(has_home=False))
+
+        root = fromstring(response.body)
+        locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]
+        assert "https://example.com/" not in locs
+        assert "https://example.com/posts" in locs
 
     @pytest.mark.asyncio
     async def test_drafts_excluded(self):
@@ -259,7 +319,7 @@ class TestSitemapEndpoint:
 
         from squishmark.routers.seo import sitemap_xml
 
-        response = await sitemap_xml(_services(mock_github, mock_cache))
+        response = await sitemap_xml(_services(mock_github, mock_cache), _theme_engine())
 
         root = fromstring(response.body)
         locs = [u.find(_ns("loc")).text for u in root.findall(_ns("url"))]

--- a/tests/test_theme_bluetech_home.py
+++ b/tests/test_theme_bluetech_home.py
@@ -85,6 +85,18 @@ def test_home_renders_hero_latest_and_featured(fake_github: FakeGitHubService) -
     assert "Secret Draft" not in body
 
 
+def test_home_hero_title_two_tone_for_single_word_camelcase(fake_github: FakeGitHubService) -> None:
+    fake_github.config = {**BLUE_TECH_CONFIG, "site": {**BLUE_TECH_CONFIG["site"], "title": "SquishMark"}}
+    fake_github.files = _files(with_featured=False)
+    app = create_app()
+    with TestClient(app) as c:
+        resp = c.get("/", follow_redirects=False)
+    assert resp.status_code == 200
+    body = resp.text
+    # Hero title splits the single CamelCase word into an accented + plain half.
+    assert '<h1 class="hero-title"><span class="accent">Squish</span>Mark</h1>' in body
+
+
 def test_home_hides_featured_when_none(fake_github: FakeGitHubService) -> None:
     with blue_tech_client(fake_github, with_featured=False) as c:
         resp = c.get("/", follow_redirects=False)

--- a/tests/test_theme_bluetech_home.py
+++ b/tests/test_theme_bluetech_home.py
@@ -1,0 +1,119 @@
+"""Cross-theme render tests for the blue-tech homepage and posts listing (#32).
+
+Blue-tech ships a bundled ``home.html``, so ``GET /`` renders a landing page
+(hero + search + latest + featured) instead of redirecting, and ``index.html``
+is a realistic ``/posts`` listing (full-width rows, tag links, pagination).
+
+These build their own app (rather than the shared ``client`` fixture) so the
+content repo and its ``config.yml`` theme selection are in place before the
+lifespan runs.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.main import create_app
+from tests.conftest import FakeGitHubService
+
+pytestmark = pytest.mark.integration
+
+BLUE_TECH_CONFIG: dict[str, Any] = {
+    "site": {
+        "title": "Test Blog",
+        "url": "https://test.example.com",
+        "description": "A blog for integration tests",
+        "author": "Test Author",
+    },
+    "theme": {"name": "blue-tech"},
+    "posts": {"per_page": 2},
+}
+
+
+def _post_body(title: str, *, draft: bool = False, featured: bool = False) -> str:
+    lines = ["---", f"title: {title}", "tags: [python, blogging]"]
+    if draft:
+        lines.append("draft: true")
+    if featured:
+        lines.append("featured: true")
+    lines.append("---")
+    return "\n".join(lines) + f"\n\n# {title}\n\nBody text for {title}.\n"
+
+
+def _files(*, with_featured: bool) -> dict[str, str]:
+    return {
+        "posts/2026-01-05-post-five.md": _post_body("Post Five", featured=with_featured),
+        "posts/2026-01-04-post-four.md": _post_body("Post Four"),
+        "posts/2026-01-03-post-three.md": _post_body("Post Three"),
+        "posts/2026-01-02-post-two.md": _post_body("Post Two"),
+        "posts/2026-01-01-post-one.md": _post_body("Post One"),
+        "posts/2026-01-06-secret-draft.md": _post_body("Secret Draft", draft=True),
+        "pages/about.md": "---\ntitle: About\nvisibility: public\n---\n\n# About\n\nPage body.\n",
+    }
+
+
+@contextmanager
+def blue_tech_client(fake_github: FakeGitHubService, *, with_featured: bool = False) -> Iterator[TestClient]:
+    """Yield a client whose content repo selects the blue-tech theme."""
+    fake_github.config = BLUE_TECH_CONFIG
+    fake_github.files = _files(with_featured=with_featured)
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+def test_home_renders_hero_latest_and_featured(fake_github: FakeGitHubService) -> None:
+    with blue_tech_client(fake_github, with_featured=True) as c:
+        resp = c.get("/", follow_redirects=False)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    body = resp.text
+    # Hero
+    assert 'class="hero"' in body
+    assert "Latest Articles" in body
+    # Search input reuses the shared partial/client
+    assert 'class="hero-search"' in body
+    assert 'data-search="input"' in body
+    # Latest and Featured sections both present
+    assert 'class="home-section"' in body
+    assert ">Latest<" in body
+    assert ">Featured<" in body
+    # Latest lists newest-first and excludes drafts
+    assert body.index("Post Five") < body.index("Post One")
+    assert "Secret Draft" not in body
+
+
+def test_home_hides_featured_when_none(fake_github: FakeGitHubService) -> None:
+    with blue_tech_client(fake_github, with_featured=False) as c:
+        resp = c.get("/", follow_redirects=False)
+    assert resp.status_code == 200
+    body = resp.text
+    assert ">Latest<" in body
+    assert ">Featured<" not in body
+
+
+def test_home_ctas_point_at_real_destinations(fake_github: FakeGitHubService) -> None:
+    with blue_tech_client(fake_github) as c:
+        resp = c.get("/", follow_redirects=False)
+    body = resp.text
+    # Browse Posts goes to the real listing, not back to the current page anchor.
+    assert '<a href="/posts" class="btn btn-primary">Browse Posts</a>' in body
+    assert 'href="#posts"' not in body
+
+
+def test_posts_listing_has_rows_tags_and_pagination(fake_github: FakeGitHubService) -> None:
+    with blue_tech_client(fake_github) as c:
+        resp = c.get("/posts")
+    assert resp.status_code == 200
+    body = resp.text
+    # Full-width rows, not the hero landing
+    assert 'class="posts-listing"' in body
+    assert 'class="post-row"' in body
+    assert 'class="hero"' not in body
+    # Clickable tag chips link to /tags/{tag}
+    assert 'href="/tags/python"' in body
+    # Pagination present (5 published posts, per_page=2 -> 3 pages)
+    assert 'class="pagination"' in body
+    assert "Page 1 of 3" in body

--- a/tests/test_theme_loader.py
+++ b/tests/test_theme_loader.py
@@ -90,6 +90,55 @@ class TestLoaderFallbackChain:
         assert name == "terminal/base.html"
 
 
+class TestHasThemeTemplate:
+    """has_theme_template counts the theme's own dir and custom overrides, but
+    never the default-theme fallback (issue #32)."""
+
+    def test_own_theme_dir_reports_true(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        (tmp_path / "terminal" / "home.html").write_text("HOME:terminal", encoding="utf-8")
+        loader = AsyncHybridLoader(tmp_path)
+        assert loader.has_theme_template("terminal", "home.html") is True
+
+    def test_default_fallback_not_counted(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        # home.html only in the default theme.
+        (tmp_path / "default" / "home.html").write_text("HOME:default", encoding="utf-8")
+        loader = AsyncHybridLoader(tmp_path)
+        # terminal has none of its own, and the default fallback must not leak.
+        assert loader.has_theme_template("terminal", "home.html") is False
+
+    def test_default_theme_own_dir_counted(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        (tmp_path / "default" / "home.html").write_text("HOME:default", encoding="utf-8")
+        loader = AsyncHybridLoader(tmp_path)
+        # For the default theme itself, its own dir is the active theme's file.
+        assert loader.has_theme_template("default", "home.html") is True
+
+    def test_custom_override_reports_true(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        loader.add_template("home.html", "HOME:custom")
+        assert loader.has_theme_template("terminal", "home.html") is True
+
+    def test_missing_reports_false(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        assert loader.has_theme_template("terminal", "home.html") is False
+
+    def test_unsafe_name_reports_false(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        loader = AsyncHybridLoader(tmp_path)
+        assert loader.has_theme_template("terminal", "../secrets.txt") is False
+
+    def test_engine_delegates_to_loader(self, tmp_path: Path):
+        _build_themes(tmp_path)
+        (tmp_path / "terminal" / "home.html").write_text("HOME:terminal", encoding="utf-8")
+        engine = _make_engine(tmp_path)
+        assert engine.has_template("home.html", "terminal") is True
+        assert engine.has_template("home.html", "default") is False
+
+
 class TestTraversalRejection:
     @pytest.mark.parametrize(
         "name",

--- a/tests/test_theme_terminal_home.py
+++ b/tests/test_theme_terminal_home.py
@@ -1,0 +1,108 @@
+"""Integration tests for the terminal theme's split homepage and listing (#32).
+
+The terminal theme ships a bundled ``home.html``, so ``GET /`` renders the
+pixel-art hero, search, latest, and featured sections. ``index.html`` is the
+``/posts`` listing with dense rows, clickable tag chips, and pagination.
+
+The active theme is switched to ``terminal`` by mutating the injected fake's
+config before the app is built, mirroring how ``test_routes_home.py`` seeds
+content ahead of the lifespan.
+"""
+
+from contextlib import contextmanager
+from copy import deepcopy
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.main import create_app
+from tests.conftest import DEFAULT_CONFIG, FakeGitHubService
+
+pytestmark = pytest.mark.integration
+
+TERMINAL_CONFIG = {**deepcopy(DEFAULT_CONFIG), "theme": {"name": "terminal"}}
+
+# A tagged, featured post so both the home featured section and the /posts tag
+# chips have something to render.
+FEATURED_POST = (
+    "---\n"
+    "title: Featured Post\n"
+    "featured: true\n"
+    "description: A standout entry.\n"
+    "tags:\n  - python\n  - web dev\n"
+    "---\n\n# Featured Post\n\nBody.\n"
+)
+
+
+@contextmanager
+def terminal_client(fake_github: FakeGitHubService, *, with_featured: bool = False) -> Iterator[TestClient]:
+    """Yield a client whose active theme is terminal."""
+    fake_github.config = TERMINAL_CONFIG
+    if with_featured:
+        fake_github.files["posts/2026-02-01-featured-post.md"] = FEATURED_POST
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+def test_root_renders_terminal_home(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github) as c:
+        resp = c.get("/")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    body = resp.text
+    # Pixel-art hero moved from index.html to home.html.
+    assert "hero-pixel-container" in body
+    assert DEFAULT_CONFIG["site"]["description"] in body
+    # Prominent terminal search input reusing the shared component.
+    assert "home-search" in body
+    assert 'class="search-input"' in body
+    # Terminal comment-style section label and latest posts.
+    assert "// latest" in body
+    assert "Post Five" in body
+
+
+def test_home_featured_section_present_when_featured(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github, with_featured=True) as c:
+        resp = c.get("/")
+    body = resp.text
+    assert "// featured" in body
+    assert "Featured Post" in body
+
+
+def test_home_featured_section_absent_when_none(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github) as c:
+        resp = c.get("/")
+    body = resp.text
+    assert "// latest" in body
+    assert "// featured" not in body
+
+
+def test_home_latest_excludes_drafts_for_anonymous(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github) as c:
+        resp = c.get("/")
+    assert "Secret Draft" not in resp.text
+
+
+def test_posts_listing_rows_tags_and_pagination(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github, with_featured=True) as c:
+        resp = c.get("/posts")
+    assert resp.status_code == 200
+    body = resp.text
+    # Dense listing rows rather than the old pixel hero.
+    assert "post-row" in body
+    assert "hero-pixel-container" not in body
+    # Clickable tag chip linking to the tag page (#10 pattern).
+    assert 'href="/tags/python"' in body
+    assert 'href="/tags/web%20dev"' in body
+    # per_page=2 with 6 published posts yields multiple pages.
+    assert "pagination" in body
+    assert "Page 1 of" in body
+
+
+def test_posts_listing_second_page(fake_github: FakeGitHubService) -> None:
+    with terminal_client(fake_github) as c:
+        resp = c.get("/posts?page=2")
+    assert resp.status_code == 200
+    assert "Newer" in resp.text

--- a/themes/blue-tech/base.html
+++ b/themes/blue-tech/base.html
@@ -44,8 +44,10 @@
                 <a href="{{ page.url }}">{{ page.title }}</a>
                 {% endfor %}
             </div>
+            {% block nav_search %}
             {% set search_mode = "input" %}
             {% include "_search.html" %}
+            {% endblock %}
             <a href="/posts" class="nav-cta">Read Blog</a>
         </div>
     </nav>

--- a/themes/blue-tech/home.html
+++ b/themes/blue-tech/home.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block title %}{{ site.title }}{% endblock %}
+
+{% macro post_card(post) %}
+<article class="post-card">
+    <div class="post-card-content">
+        {% if post.tags %}
+        <div class="post-tags">
+            {% for tag in post.tags %}
+            <a class="tag tag-link" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <h3 class="post-title">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+        </h3>
+        {% if post.description %}
+        <p class="post-excerpt">{{ post.description }}</p>
+        {% endif %}
+        {% if post.date %}
+        <time class="post-date" datetime="{{ post.date }}">
+            {{ post.date | format_date }}
+        </time>
+        {% endif %}
+    </div>
+</article>
+{% endmacro %}
+
+{% block content %}
+<section class="hero">
+    <span class="hero-label">Latest Articles</span>
+    <h1 class="hero-title">{{ site.title | accent_first_word }}</h1>
+    <p class="hero-subtitle">{{ site.description }}</p>
+    <div class="hero-buttons">
+        <a href="/posts" class="btn btn-primary">Browse Posts</a>
+        <a href="/about" class="btn btn-secondary">About Me</a>
+    </div>
+    <div class="hero-search">
+        {% set search_mode = "input" %}
+        {% include "_search.html" %}
+    </div>
+</section>
+
+{% if latest_posts %}
+<section class="home-section">
+    <div class="home-section-head">
+        <h2 class="home-section-title">Latest</h2>
+        <a href="/posts" class="home-section-link">View all &rarr;</a>
+    </div>
+    <div class="posts-grid">
+        {% for post in latest_posts %}
+        {{ post_card(post) }}
+        {% endfor %}
+    </div>
+</section>
+{% endif %}
+
+{% if featured_posts %}
+<section class="home-section">
+    <div class="home-section-head">
+        <h2 class="home-section-title">Featured</h2>
+    </div>
+    <div class="posts-grid">
+        {% for post in featured_posts %}
+        {{ post_card(post) }}
+        {% endfor %}
+    </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/themes/blue-tech/home.html
+++ b/themes/blue-tech/home.html
@@ -27,6 +27,9 @@
 </article>
 {% endmacro %}
 
+{# The hero has its own prominent search input #}
+{% block nav_search %}{% endblock %}
+
 {% block content %}
 <section class="hero">
     <span class="hero-label">Latest Articles</span>

--- a/themes/blue-tech/index.html
+++ b/themes/blue-tech/index.html
@@ -1,43 +1,35 @@
 {% extends "base.html" %}
 
-{% block title %}{{ site.title }}{% endblock %}
+{% block title %}Posts &middot; {{ site.title }}{% endblock %}
 
 {% block content %}
-<section class="hero">
-    <span class="hero-label">Latest Articles</span>
-    <h1 class="hero-title">{{ site.title | accent_first_word }}</h1>
-    <p class="hero-subtitle">{{ site.description }}</p>
-    <div class="hero-buttons">
-        <a href="#posts" class="btn btn-primary">Browse Posts</a>
-        <a href="/about" class="btn btn-secondary">About Me</a>
-    </div>
-</section>
+<section class="posts-listing">
+    <header class="posts-listing-header">
+        <h1 class="posts-listing-title">All Posts</h1>
+    </header>
 
-<section id="posts" class="posts-section">
     {% if posts %}
-    <div class="posts-grid">
+    <div class="post-rows">
         {% for post in posts %}
-        <article class="post-card">
-            <div class="post-card-content">
-                {% if post.tags %}
-                <div class="post-tags">
-                    {% for tag in post.tags %}
-                    <a class="tag tag-link" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
-                    {% endfor %}
-                </div>
-                {% endif %}
-                <h2 class="post-title">
-                    <a href="{{ post.url }}">{{ post.title }}</a>
-                </h2>
-                {% if post.description %}
-                <p class="post-excerpt">{{ post.description }}</p>
-                {% endif %}
-                {% if post.date %}
-                <time class="post-date" datetime="{{ post.date }}">
-                    {{ post.date | format_date }}
-                </time>
-                {% endif %}
+        <article class="post-row">
+            <h2 class="post-row-title">
+                <a href="{{ post.url }}">{{ post.title }}</a>
+            </h2>
+            {% if post.date %}
+            <time class="post-row-date" datetime="{{ post.date }}">
+                {{ post.date | format_date }}
+            </time>
+            {% endif %}
+            {% if post.description %}
+            <p class="post-row-excerpt">{{ post.description }}</p>
+            {% endif %}
+            {% if post.tags %}
+            <div class="post-tags">
+                {% for tag in post.tags %}
+                <a class="tag tag-link" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
+                {% endfor %}
             </div>
+            {% endif %}
         </article>
         {% endfor %}
     </div>

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -1349,6 +1349,144 @@ img {
     flex-shrink: 0;
 }
 
+/* ============================================
+   Homepage — hero search
+   ============================================ */
+.hero-search {
+    max-width: 560px;
+    margin: 40px auto 0;
+}
+
+.hero-search .search {
+    display: block;
+    width: 100%;
+}
+
+.hero-search .search-input {
+    width: 100%;
+    padding: 0.9rem 1.4rem;
+    font-size: 1rem;
+    border-radius: 999px;
+    text-align: left;
+}
+
+.hero-search .search-dropdown {
+    left: 0;
+    right: 0;
+    width: auto;
+}
+
+/* ============================================
+   Homepage — Latest / Featured sections
+   ============================================ */
+.home-section {
+    max-width: var(--max-width);
+    margin: 0 auto 4rem;
+    padding: 0 24px;
+}
+
+.home-section-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.home-section-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.home-section-link {
+    color: var(--color-accent-light);
+    font-size: 0.9rem;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.home-section-link:hover {
+    color: var(--color-accent);
+}
+
+/* ============================================
+   Posts listing — full-width rows
+   ============================================ */
+.posts-listing {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 3rem 24px 4rem;
+}
+
+.posts-listing-header {
+    margin-bottom: 2.5rem;
+}
+
+.posts-listing-title {
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-weight: 800;
+    line-height: 1.2;
+}
+
+.post-rows {
+    display: flex;
+    flex-direction: column;
+}
+
+.post-row {
+    padding: 1.75rem 0;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.post-row:first-child {
+    padding-top: 0;
+}
+
+.post-row-title {
+    font-size: 1.4rem;
+    font-weight: 700;
+    line-height: 1.3;
+    margin-bottom: 0.4rem;
+}
+
+.post-row-title a {
+    color: var(--color-text);
+    transition: color var(--transition);
+}
+
+.post-row-title a:hover {
+    color: var(--color-accent);
+}
+
+.post-row-date {
+    display: block;
+    color: var(--color-text-dark);
+    font-size: 0.85rem;
+    margin-bottom: 0.6rem;
+}
+
+.post-row-excerpt {
+    color: var(--color-text-subtle);
+    line-height: 1.6;
+    margin-bottom: 0.9rem;
+}
+
+.post-row .post-tags {
+    margin-top: 0.25rem;
+}
+
+@media (max-width: 768px) {
+    .home-section {
+        padding: 0 16px;
+        margin-bottom: 3rem;
+    }
+
+    .posts-listing {
+        padding: 2rem 16px 3rem;
+    }
+}
+
 /* Related posts */
 .related-posts {
     margin-top: 2.5rem;

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -189,7 +189,7 @@ img {
 .hero {
     position: relative;
     text-align: center;
-    padding: 180px 24px 120px;
+    padding: 96px 24px 48px;
     max-width: 700px;
     margin: 0 auto;
 }
@@ -1354,7 +1354,7 @@ img {
    ============================================ */
 .hero-search {
     max-width: 560px;
-    margin: 40px auto 0;
+    margin: 28px auto 0;
 }
 
 .hero-search .search {
@@ -1394,7 +1394,7 @@ img {
 }
 
 .home-section-title {
-    font-size: 1.75rem;
+    font-size: 1.05rem;
     font-weight: 700;
     line-height: 1.2;
 }

--- a/themes/blue-tech/static/style.css
+++ b/themes/blue-tech/static/style.css
@@ -1394,8 +1394,12 @@ img {
 }
 
 .home-section-title {
-    font-size: 1.05rem;
-    font-weight: 700;
+    color: var(--color-accent);
+    opacity: 0.75;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
     line-height: 1.2;
 }
 

--- a/themes/terminal/base.html
+++ b/themes/terminal/base.html
@@ -56,8 +56,10 @@
                 {% for page in nav_pages %}
                 <a href="{{ page.url }}">{{ page.title }}</a>
                 {% endfor %}
+                {% block nav_search %}
                 {% set search_mode = "button" %}
                 {% include "_search.html" %}
+                {% endblock %}
             </div>
         </div>
     </nav>

--- a/themes/terminal/home.html
+++ b/themes/terminal/home.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+
+{% block title %}{{ site.title }}{% endblock %}
+
+{% block nav_logo %}
+{% if theme.nav_image %}
+<img src="{{ theme.nav_image }}" alt="{{ site.title }}" class="nav-image nav-image-muted">
+{% else %}
+<div class="nav-pixel-muted" data-pixel-text="{{ site.title }}"
+     data-pixel-size="8" data-pixel-gap="0"
+     data-pixel-skew="-6"
+     data-pixel-split="0"
+     data-pixel-color1="#3d4555" data-pixel-color2="#3d4555"></div>
+{% endif %}
+{% endblock %}
+
+{% macro post_card(post) %}
+<article class="post-card">
+    <div class="post-card-content">
+        {% if post.date %}
+        <time class="post-date" datetime="{{ post.date }}">
+            {{ post.date | format_date }}
+        </time>
+        {% endif %}
+        <h3 class="post-title">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+        </h3>
+        {% if post.description %}
+        <p class="post-excerpt">{{ post.description }}</p>
+        {% endif %}
+        {% if post.tags %}
+        <div class="post-tags">
+            {% for tag in post.tags %}
+            <a class="tag tag-link {% if loop.index is odd %}tag-green{% else %}tag-blue{% endif %}" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+    </div>
+</article>
+{% endmacro %}
+
+{% block content %}
+<section class="hero">
+    {% if theme.hero_image %}
+    <img src="{{ theme.hero_image }}" alt="{{ site.title }}" class="hero-image">
+    {% else %}
+    <div class="hero-pixel-container"
+         data-pixel-text="{{ site.title }}"
+         data-pixel-size="6" data-pixel-gap="1"
+         data-pixel-cursor="solid" data-pixel-skew="0"
+         data-pixel-split="6"
+         data-pixel-color1="#3b82f6" data-pixel-color2="#4ade80"></div>
+    {% endif %}
+    <p class="hero-subtitle">{{ site.description }}</p>
+
+    <div class="home-search">
+        {% set search_mode = "input" %}
+        {% include "_search.html" %}
+    </div>
+</section>
+
+<div class="home-sections">
+    <section class="home-section" id="latest">
+        <div class="section-header">
+            <h2 class="section-label">// latest</h2>
+            <a class="section-more" href="/posts">all posts &rarr;</a>
+        </div>
+        {% if latest_posts %}
+        <div class="posts-grid">
+            {% for post in latest_posts %}
+            {{ post_card(post) }}
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="no-posts">
+            <p>No posts yet. Check back soon!</p>
+        </div>
+        {% endif %}
+    </section>
+
+    {% if featured_posts %}
+    <section class="home-section" id="featured">
+        <div class="section-header">
+            <h2 class="section-label">// featured</h2>
+        </div>
+        <div class="posts-grid">
+            {% for post in featured_posts %}
+            {{ post_card(post) }}
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}

--- a/themes/terminal/home.html
+++ b/themes/terminal/home.html
@@ -52,12 +52,14 @@
          data-pixel-color1="#3b82f6" data-pixel-color2="#4ade80"></div>
     {% endif %}
     <p class="hero-subtitle">{{ site.description }}</p>
-
-    <div class="home-search">
-        {% set search_mode = "input" %}
-        {% include "_search.html" %}
-    </div>
 </section>
+
+{# Outside .hero: its overflow hidden (pixel glow clipping) would cut off
+   the search results dropdown. #}
+<div class="home-search">
+    {% set search_mode = "input" %}
+    {% include "_search.html" %}
+</div>
 
 <div class="home-sections">
     <section class="home-section" id="latest">

--- a/themes/terminal/home.html
+++ b/themes/terminal/home.html
@@ -39,6 +39,9 @@
 </article>
 {% endmacro %}
 
+{# The hero has its own prominent search input #}
+{% block nav_search %}{% endblock %}
+
 {% block content %}
 <section class="hero">
     {% if theme.hero_image %}

--- a/themes/terminal/index.html
+++ b/themes/terminal/index.html
@@ -1,62 +1,38 @@
 {% extends "base.html" %}
 
-{% block title %}{{ site.title }}{% endblock %}
-
-{% block nav_logo %}
-{% if theme.nav_image %}
-<img src="{{ theme.nav_image }}" alt="{{ site.title }}" class="nav-image nav-image-muted">
-{% else %}
-<div class="nav-pixel-muted" data-pixel-text="{{ site.title }}"
-     data-pixel-size="8" data-pixel-gap="0"
-     data-pixel-skew="-6"
-     data-pixel-split="0"
-     data-pixel-color1="#3d4555" data-pixel-color2="#3d4555"></div>
-{% endif %}
-{% endblock %}
+{% block title %}Posts - {{ site.title }}{% endblock %}
 
 {% block content %}
-<section class="hero">
-    {% if theme.hero_image %}
-    <img src="{{ theme.hero_image }}" alt="{{ site.title }}" class="hero-image">
-    {% else %}
-    <div class="hero-pixel-container"
-         data-pixel-text="{{ site.title }}"
-         data-pixel-size="6" data-pixel-gap="1"
-         data-pixel-cursor="solid" data-pixel-skew="0"
-         data-pixel-split="6"
-         data-pixel-color1="#3b82f6" data-pixel-color2="#4ade80"></div>
-    {% endif %}
-    <p class="hero-subtitle">{{ site.description }}</p>
-</section>
+<section class="posts-listing">
+    <h1 class="listing-title">// posts</h1>
 
-<section id="posts" class="posts-section">
     {% if posts %}
-    <div class="posts-grid">
+    <ul class="post-rows">
         {% for post in posts %}
-        <article class="post-card">
-            <div class="post-card-content">
+        <li class="post-row">
+            <div class="post-row-head">
+                <h2 class="post-row-title">
+                    <a href="{{ post.url }}">{{ post.title }}</a>
+                </h2>
                 {% if post.date %}
                 <time class="post-date" datetime="{{ post.date }}">
                     {{ post.date | format_date }}
                 </time>
                 {% endif %}
-                <h2 class="post-title">
-                    <a href="{{ post.url }}">{{ post.title }}</a>
-                </h2>
-                {% if post.description %}
-                <p class="post-excerpt">{{ post.description }}</p>
-                {% endif %}
-                {% if post.tags %}
-                <div class="post-tags">
-                    {% for tag in post.tags %}
-                    <a class="tag tag-link {% if loop.index is odd %}tag-green{% else %}tag-blue{% endif %}" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
-                    {% endfor %}
-                </div>
-                {% endif %}
             </div>
-        </article>
+            {% if post.description %}
+            <p class="post-row-desc">{{ post.description }}</p>
+            {% endif %}
+            {% if post.tags %}
+            <div class="post-tags">
+                {% for tag in post.tags %}
+                <a class="tag tag-link {% if loop.index is odd %}tag-green{% else %}tag-blue{% endif %}" href="/tags/{{ tag | urlencode }}">{{ tag }}</a>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </li>
         {% endfor %}
-    </div>
+    </ul>
 
     {% if pagination.total_pages > 1 %}
     <nav class="pagination">

--- a/themes/terminal/static/css/style.css
+++ b/themes/terminal/static/css/style.css
@@ -356,6 +356,160 @@ img {
 }
 
 /* ============================================
+   Homepage (home.html)
+   ============================================ */
+.home-search {
+    max-width: 560px;
+    margin: 28px auto 0;
+}
+
+.home-search .search {
+    display: block;
+    position: relative;
+    width: 100%;
+}
+
+.home-search .search-input {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(74, 222, 128, 0.35);
+    border-radius: var(--radius-sm);
+}
+
+.home-search .search-input:focus {
+    border-color: var(--color-green);
+    box-shadow: 0 0 0 1px rgba(74, 222, 128, 0.3);
+}
+
+.home-search .search-dropdown {
+    left: 0;
+    right: 0;
+    width: auto;
+    top: calc(100% + 8px);
+}
+
+.home-sections {
+    position: relative;
+    z-index: 1;
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 32px 4rem;
+}
+
+.home-section {
+    margin-top: 3rem;
+}
+
+.section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+}
+
+.section-label {
+    font-family: var(--font-mono);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-green);
+}
+
+.section-more {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color var(--transition);
+}
+
+.section-more:hover {
+    color: var(--color-blue);
+}
+
+/* ============================================
+   Posts Listing (index.html rows)
+   ============================================ */
+.posts-listing {
+    position: relative;
+    z-index: 1;
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 3rem 32px 4rem;
+}
+
+.posts-listing .listing-title {
+    color: var(--color-green);
+    font-size: 1.25rem;
+}
+
+.post-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-top: 1px solid var(--color-border);
+}
+
+.post-row {
+    padding: 1.25rem 0;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.post-row-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.post-row-title {
+    font-family: var(--font-mono);
+    font-size: 1.05rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+
+.post-row-title a {
+    color: var(--color-text);
+    text-decoration: none;
+}
+
+.post-row-title a:hover {
+    color: var(--color-blue);
+}
+
+.post-row .post-date {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-green);
+    white-space: nowrap;
+}
+
+.post-row-desc {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.5;
+    margin-top: 0.4rem;
+}
+
+.post-row .post-tags {
+    margin-top: 0.6rem;
+}
+
+@media (max-width: 768px) {
+    .home-sections {
+        padding: 0 16px 3rem;
+    }
+
+    .posts-listing {
+        padding: 2rem 16px 3rem;
+    }
+}
+
+/* ============================================
    Single Post/Page
    ============================================ */
 .post, .page {


### PR DESCRIPTION
Closes #32
Fixes #129

Themes can now ship a real homepage: GET / renders home.html when the active theme provides one (own directory or content-repo override, never via the default-theme fallback, so it stays opt-in per theme); themes without one keep the historical 302 to /posts.

- Engine: home router with latest_posts/featured_posts context, theme-scoped has_template resolution, sitemap includes / only when a homepage resolves, canonical URL for /
- Blue-tech: landing hero promoted to home.html with fixed CTAs, prominent hero search (reusing the existing search client), Latest and Featured card sections with quiet accent eyebrow headers; index.html rebuilt as a full-width row listing with linked tag chips and pagination
- Terminal: pixel-art hero moved to home.html with search, // latest and // featured sections; index.html rebuilt as a dense terminal-styled listing
- Default: unchanged by design; / still redirects to its listing
- Navbar search is now a nav_search template block so homepages with their own search hide the redundant navbar one (both new homepages do)
- accent_first_word now splits single-word CamelCase titles on the last interior capital so SquishMark renders two tone; space and capital rules are mutually exclusive and multi-word behavior is unchanged (#129)

Tests: 521 total, covering homepage resolution semantics (own theme yes, fallback no, override yes), redirect fallback, sitemap inclusion/exclusion, latest/featured context, draft gating, per-theme render tests, and the accent split rules.

Verification: browser-verified across all three themes on live servers including hero search (fuzzy queries return results, dropdown clipping fixed on terminal), navbar search hidden on homepages and present elsewhere, default pixel-unchanged, plus a maintainer walkthrough in side-by-side tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)