### PR TITLE
feat(engine): support nested pages in subdirectories under pages/

### DIFF
--- a/src/squishmark/routers/admin.py
+++ b/src/squishmark/routers/admin.py
@@ -409,7 +409,7 @@ async def refresh_cache(
         await github_service.get_file(path, use_cache=True)
 
     # Fetch all pages
-    page_files = await github_service.list_directory("pages", use_cache=True)
+    page_files = await github_service.list_directory("pages", use_cache=True, recursive=True)
     for path in page_files:
         await github_service.get_file(path, use_cache=True)
 

--- a/src/squishmark/routers/pages.py
+++ b/src/squishmark/routers/pages.py
@@ -12,7 +12,7 @@ from squishmark.services.notes import NotesService
 router = APIRouter(tags=["pages"])
 
 
-@router.get("/{slug}", response_class=HTMLResponse)
+@router.get("/{slug:path}", response_class=HTMLResponse)
 async def get_page(
     request: Request,
     context: SiteContextDep,
@@ -21,13 +21,17 @@ async def get_page(
     db: AsyncSession = Depends(get_db_session),
 ) -> HTMLResponse:
     """
-    Get a static page by slug.
+    Get a static page by slug, including nested pages like /docs/setup.
 
     This route has lower priority than /posts routes and is designed
     to be a catch-all for pages like /about, /contact, etc.
     """
     config = context.config
     markdown_service = context.markdown
+
+    # Reject empty, dot, and traversal segments before touching the content store
+    if not slug or any(not seg or seg.startswith(".") for seg in slug.split("/")):
+        raise HTTPException(status_code=404, detail="Page not found")
 
     # Try to find the page
     page_path = f"pages/{slug}.md"

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -83,7 +83,7 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
         await github_service.get_file(path, use_cache=True)
 
     # Fetch all pages
-    page_files = await github_service.list_directory("pages", use_cache=True)
+    page_files = await github_service.list_directory("pages", use_cache=True, recursive=True)
     for path in page_files:
         await github_service.get_file(path, use_cache=True)
 

--- a/src/squishmark/services/content.py
+++ b/src/squishmark/services/content.py
@@ -259,7 +259,7 @@ async def get_all_pages(
     include_hidden: bool = False,
 ) -> list[Page]:
     """Fetch and parse all pages from the content repository."""
-    page_files = await github_service.list_directory("pages")
+    page_files = await github_service.list_directory("pages", recursive=True)
 
     pages: list[Page] = []
     for path in page_files:

--- a/src/squishmark/services/github.py
+++ b/src/squishmark/services/github.py
@@ -220,7 +220,7 @@ class GitHubService:
 
         return result
 
-    async def _list_local_directory(self, path: str) -> list[str]:
+    async def _list_local_directory(self, path: str, recursive: bool = False) -> list[str]:
         """List files in a local directory."""
         try:
             base_path = self._get_local_path()
@@ -233,9 +233,14 @@ class GitHubService:
 
             def _list_files() -> list[str]:
                 files = []
-                for item in dir_path.iterdir():
-                    if item.is_file() and not item.name.startswith("."):
-                        files.append(f"{path}/{item.name}")
+                items = dir_path.rglob("*") if recursive else dir_path.iterdir()
+                for item in items:
+                    if not item.is_file():
+                        continue
+                    rel = item.relative_to(base_path)
+                    if any(part.startswith(".") for part in rel.parts):
+                        continue
+                    files.append(str(rel))
                 return sorted(files)
 
             return await loop.run_in_executor(None, _list_files)
@@ -266,7 +271,37 @@ class GitHubService:
             logger.warning("Failed to list GitHub directory %s: %s", url, exc)
             return []
 
-    async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
+    async def _list_github_tree(self, path: str, ref: str = "main") -> list[str]:
+        """List files under a directory recursively using the git trees API."""
+        client = await self._get_client()
+        repo = self.settings.github_content_repo
+
+        url = f"{self.GITHUB_API_BASE}/repos/{repo}/git/trees/{ref}"
+        params = {"recursive": "1"}
+
+        try:
+            response = await client.get(url, params=params)
+            if response.status_code == 404:
+                return []
+            response.raise_for_status()
+
+            data = response.json()
+            if data.get("truncated"):
+                logger.warning("Git tree for %s is truncated; some files may be missing", repo)
+
+            prefix = f"{path}/"
+            return sorted(
+                item["path"]
+                for item in data.get("tree", [])
+                if item.get("type") == "blob" and item.get("path", "").startswith(prefix)
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("Failed to list GitHub tree %s: %s", url, exc)
+            return []
+
+    async def list_directory(
+        self, path: str, ref: str = "main", use_cache: bool = True, recursive: bool = False
+    ) -> list[str]:
         """
         List files in a directory.
 
@@ -274,11 +309,12 @@ class GitHubService:
             path: Directory path within the repository
             ref: Git ref (branch, tag, or commit) - only used for GitHub
             use_cache: Whether to use cached content
+            recursive: Whether to include files in subdirectories
 
         Returns:
             List of file paths within the directory
         """
-        cache_key = f"dir:{path}:{ref}"
+        cache_key = f"dir:{path}:{ref}:{int(recursive)}"
 
         # Check cache first
         if use_cache:
@@ -288,7 +324,9 @@ class GitHubService:
 
         # Fetch from source
         if self.settings.is_local_content:
-            result = await self._list_local_directory(path)
+            result = await self._list_local_directory(path, recursive=recursive)
+        elif recursive:
+            result = await self._list_github_tree(path, ref)
         else:
             result = await self._list_github_directory(path, ref)
 

--- a/src/squishmark/services/markdown.py
+++ b/src/squishmark/services/markdown.py
@@ -227,8 +227,9 @@ class MarkdownService:
         html, _toc = self.render_markdown(markdown_content)
         html = rewrite_image_urls(html, path)
 
-        # Extract slug from path (e.g., "pages/about.md" -> "about")
-        slug = self._extract_slug(path, strip_date=False)
+        # Extract slug from path, keeping subdirectories
+        # (e.g., "pages/about.md" -> "about", "pages/docs/setup.md" -> "docs/setup")
+        slug = self._extract_slug(path, strip_date=False, keep_dirs=True)
 
         # Auto-generate description from content if not set in frontmatter
         description = frontmatter.description
@@ -271,10 +272,10 @@ class MarkdownService:
             chunk = chunk.rsplit(" ", 1)[0]
         return chunk + "..."
 
-    def _extract_slug(self, path: str, strip_date: bool = True) -> str:
+    def _extract_slug(self, path: str, strip_date: bool = True, keep_dirs: bool = False) -> str:
         """Extract slug from a file path."""
-        # Get filename without extension
-        filename = path.split("/")[-1]
+        segments = path.split("/")
+        filename = segments[-1]
         if filename.endswith(".md"):
             filename = filename[:-3]
 
@@ -282,6 +283,11 @@ class MarkdownService:
             # Remove date prefix if present (YYYY-MM-DD-)
             date_pattern = re.compile(r"^\d{4}-\d{2}-\d{2}-")
             filename = date_pattern.sub("", filename)
+
+        if keep_dirs and len(segments) > 2:
+            # Keep subdirectories below the top-level content dir
+            # ("pages/docs/setup.md" -> "docs/setup")
+            return "/".join([*segments[1:-1], filename])
 
         return filename
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,15 +59,16 @@ class FakeGitHubService:
             return None
         return GitHubBinaryFile(path=path, content=content, content_type=_content_type_for(path))
 
-    async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
+    async def list_directory(
+        self, path: str, ref: str = "main", use_cache: bool = True, recursive: bool = False
+    ) -> list[str]:
         prefix = f"{path.rstrip('/')}/"
         children: set[str] = set()
         for key in (*self.files, *self.binary_files):
             if key.startswith(prefix):
                 remainder = key[len(prefix) :]
-                # Only direct children (no nested subdirectories), matching the
-                # real service which lists a single directory level.
-                if "/" not in remainder:
+                # Direct children only unless recursive, matching the real service.
+                if recursive or "/" not in remainder:
                     children.add(key)
         return sorted(children)
 
@@ -237,6 +238,16 @@ def fake_github(_reset_environment: FakeGitHubService | None) -> FakeGitHubServi
 _SEED_ROUTE = "/_test/seed-session"
 
 
+def promote_last_route(app: Any) -> None:
+    """Move the most recently added route ahead of the pages catch-all.
+
+    Test-only routes are registered after ``create_app()``, which would leave
+    them shadowed by the ``/{slug:path}`` catch-all (routes match in
+    registration order).
+    """
+    app.router.routes.insert(0, app.router.routes.pop())
+
+
 @pytest.fixture
 def client() -> Iterator[TestClient]:
     """Anonymous client over the real ``create_app()`` with lifespan active."""
@@ -266,6 +277,8 @@ def admin_client() -> Iterator[TestClient]:
         request.session["user"] = {"login": "admin-user"}
         return {"ok": True}
 
+    promote_last_route(app)
+
     with TestClient(app, base_url="https://testserver") as test_client:
         resp = test_client.get(_SEED_ROUTE)
         assert resp.status_code == 200, resp.text
@@ -292,6 +305,8 @@ def seeded_client() -> Iterator[Callable[[dict[str, Any]], TestClient]]:
             for key, value in session_data.items():
                 request.session[key] = value
             return {"ok": True}
+
+        promote_last_route(app)
 
         test_client = TestClient(app, base_url="https://testserver")
         test_client.__enter__()

--- a/tests/test_analytics_filtering.py
+++ b/tests/test_analytics_filtering.py
@@ -8,6 +8,7 @@ from fastapi.responses import HTMLResponse
 from httpx import ASGITransport, AsyncClient
 
 from squishmark.services.analytics_middleware import is_bot_user_agent
+from tests.conftest import promote_last_route
 
 
 @pytest.mark.parametrize(
@@ -90,6 +91,8 @@ async def _assert_track_called(headers: dict, path: str, expected: bool, add_htm
             @app.get("/_test/html", response_class=HTMLResponse)
             async def _test_html():
                 return HTMLResponse("<html><body>test</body></html>")
+
+            promote_last_route(app)
 
         # ASGITransport does not emit lifespan events, so run the lifespan
         # explicitly to build the service container on app.state.

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -94,9 +94,11 @@ class _CountingGitHub:
     async def get_config(self, use_cache: bool = True) -> dict[str, Any]:
         return _CONFIG
 
-    async def list_directory(self, path: str, ref: str = "main", use_cache: bool = True) -> list[str]:
+    async def list_directory(
+        self, path: str, ref: str = "main", use_cache: bool = True, recursive: bool = False
+    ) -> list[str]:
         prefix = f"{path.rstrip('/')}/"
-        return sorted(k for k in self.files if k.startswith(prefix) and "/" not in k[len(prefix) :])
+        return sorted(k for k in self.files if k.startswith(prefix) and (recursive or "/" not in k[len(prefix) :]))
 
     async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
         self.get_file_calls += 1

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -157,6 +157,25 @@ def test_extract_slug(markdown_service):
     assert slug_no_date == "about"
 
 
+def test_extract_slug_keeps_subdirectories(markdown_service):
+    """keep_dirs preserves path segments below the top-level content dir."""
+    nested = markdown_service._extract_slug("pages/docs/setup.md", strip_date=False, keep_dirs=True)
+    assert nested == "docs/setup"
+
+    deep = markdown_service._extract_slug("pages/docs/guides/themes.md", strip_date=False, keep_dirs=True)
+    assert deep == "docs/guides/themes"
+
+    flat = markdown_service._extract_slug("pages/about.md", strip_date=False, keep_dirs=True)
+    assert flat == "about"
+
+
+def test_parse_page_nested_slug_and_url(markdown_service):
+    """Nested page files get multi-segment slugs and matching URLs."""
+    page = markdown_service.parse_page("pages/docs/setup.md", "---\ntitle: Setup\n---\n\nBody.\n")
+    assert page.slug == "docs/setup"
+    assert page.url == "/docs/setup"
+
+
 def test_heading_text_is_anchor_link(markdown_service):
     """Heading text should be wrapped in a self-referencing anchor link."""
     html, _toc = markdown_service.render_markdown("## Hello World")

--- a/tests/test_nested_pages.py
+++ b/tests/test_nested_pages.py
@@ -1,0 +1,131 @@
+"""Tests for nested pages support: recursive listing and multi-segment slugs.
+
+Covers the recursive ``list_directory`` paths (local ``rglob`` and the GitHub
+git trees API) and the ``/{slug:path}`` page route serving pages from
+subdirectories of ``pages/``.
+"""
+
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.config import Settings
+from squishmark.services.cache import Cache
+from squishmark.services.github import GitHubService
+
+
+@pytest.fixture
+def local_service(tmp_path):
+    """A GitHubService over a local content tree with nested pages."""
+    (tmp_path / "pages" / "docs").mkdir(parents=True)
+    (tmp_path / "pages" / "about.md").write_text("---\ntitle: About\n---\n", encoding="utf-8")
+    (tmp_path / "pages" / "docs" / "setup.md").write_text("---\ntitle: Setup\n---\n", encoding="utf-8")
+    (tmp_path / "pages" / "docs" / ".draft.md").write_text("hidden", encoding="utf-8")
+    (tmp_path / "pages" / ".obsidian").mkdir()
+    (tmp_path / "pages" / ".obsidian" / "workspace.md").write_text("hidden", encoding="utf-8")
+
+    settings = Settings(github_content_repo=f"file://{tmp_path}")
+    cache = Cache(ttl_seconds=300)
+    return GitHubService(settings, cache)
+
+
+@pytest.mark.asyncio
+async def test_local_listing_recursive(local_service):
+    files = await local_service.list_directory("pages", recursive=True)
+    assert files == ["pages/about.md", "pages/docs/setup.md"]
+
+
+@pytest.mark.asyncio
+async def test_local_listing_recursive_skips_dotted_paths(local_service):
+    files = await local_service.list_directory("pages", recursive=True)
+    assert not any(".draft" in f or ".obsidian" in f for f in files)
+
+
+@pytest.mark.asyncio
+async def test_local_listing_non_recursive_unchanged(local_service):
+    files = await local_service.list_directory("pages")
+    assert files == ["pages/about.md"]
+
+
+def _trees_transport(payload: dict, status_code: int = 200) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "/git/trees/main" in request.url.path
+        assert request.url.params.get("recursive") == "1"
+        return httpx.Response(status_code, content=json.dumps(payload))
+
+    return httpx.MockTransport(handler)
+
+
+def _github_service_with_transport(transport: httpx.MockTransport) -> GitHubService:
+    settings = Settings(github_content_repo="owner/repo")
+    service = GitHubService(settings, Cache(ttl_seconds=300))
+    service._client = httpx.AsyncClient(transport=transport)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_github_listing_recursive_uses_trees_api():
+    payload = {
+        "tree": [
+            {"path": "pages", "type": "tree"},
+            {"path": "pages/about.md", "type": "blob"},
+            {"path": "pages/docs", "type": "tree"},
+            {"path": "pages/docs/setup.md", "type": "blob"},
+            {"path": "posts/2026-01-01-hello.md", "type": "blob"},
+            {"path": "config.yml", "type": "blob"},
+        ],
+        "truncated": False,
+    }
+    service = _github_service_with_transport(_trees_transport(payload))
+    files = await service.list_directory("pages", recursive=True)
+    assert files == ["pages/about.md", "pages/docs/setup.md"]
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_github_listing_recursive_missing_ref_returns_empty():
+    service = _github_service_with_transport(_trees_transport({}, status_code=404))
+    files = await service.list_directory("pages", recursive=True)
+    assert files == []
+    await service.close()
+
+
+# --- Route integration -----------------------------------------------------
+
+
+@pytest.mark.integration
+def test_nested_page_renders(fake_github, client: TestClient) -> None:
+    fake_github.files["pages/docs/setup.md"] = "---\ntitle: Setup Guide\n---\n\n# Setup Guide\n\nSteps.\n"
+    resp = client.get("/docs/setup")
+    assert resp.status_code == 200
+    assert "Setup Guide" in resp.text
+
+
+@pytest.mark.integration
+def test_nested_page_unknown_404(client: TestClient) -> None:
+    resp = client.get("/docs/no-such-page")
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+def test_dot_segments_rejected(client: TestClient) -> None:
+    # Percent-encoded dot segments reach the route without client-side URL
+    # normalization and must not be forwarded to the content store.
+    resp = client.get("/docs/%2e%2e/secret")
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+def test_dotfile_page_rejected(client: TestClient) -> None:
+    resp = client.get("/.well-known/anything")
+    assert resp.status_code == 404
+
+
+@pytest.mark.integration
+def test_nested_page_in_sitemap(fake_github, client: TestClient) -> None:
+    fake_github.files["pages/docs/setup.md"] = "---\ntitle: Setup Guide\n---\n\nSteps.\n"
+    resp = client.get("/sitemap.xml")
+    assert resp.status_code == 200
+    assert "/docs/setup" in resp.text

--- a/tests/test_routes_home.py
+++ b/tests/test_routes_home.py
@@ -13,7 +13,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from squishmark.main import create_app
-from tests.conftest import FakeGitHubService
+from tests.conftest import FakeGitHubService, promote_last_route
 
 pytestmark = pytest.mark.integration
 
@@ -39,6 +39,8 @@ def home_client(fake_github: FakeGitHubService, *, admin: bool = False) -> Itera
         async def _seed(request: Request) -> dict:
             request.session["user"] = {"login": "admin-user"}
             return {"ok": True}
+
+        promote_last_route(app)
 
     base_url = "https://testserver" if admin else "http://testserver"
     with TestClient(app, base_url=base_url) as client:


### PR DESCRIPTION
## Summary

Adds nested pages support so content repos can organize pages in subdirectories, e.g. `pages/docs/getting-started.md` served at `/docs/getting-started`. Needed for the docs section of the official site (#85, "Build squishmark.xeek.dev as a self-hosted SquishMark site").

Closes #131 (Support nested pages in subdirectories under pages/).

## Changes

- `GitHubService.list_directory` gains a `recursive` option: the git trees API (`/git/trees/{ref}?recursive=1`) for GitHub content, `rglob` for local `file://` content. Dotted files and directories (e.g. `.obsidian/`) are skipped. Cache keys include the recursive flag.
- Page slugs keep subdirectories below the top-level content dir (`pages/docs/setup.md` -> `docs/setup`); `Page.url` needs no change.
- The pages catch-all route matches `/{slug:path}` and rejects empty, dot, and traversal segments before touching the content store.
- Pages listings in content, admin cache warm, and webhook cache warm are recursive; posts listing is unchanged (flat).
- Test infra: routes registered after `create_app()` (session seeding, analytics HTML stub) were shadowed by the new catch-all, so a shared `promote_last_route` conftest helper moves them ahead in match order.

## Testing

- New `tests/test_nested_pages.py`: recursive local and GitHub-trees listing (MockTransport), nested route rendering, 404s, encoded dot-segment rejection, sitemap inclusion.
- Slug unit tests for nested paths in `tests/test_markdown.py`.
- `python scripts/run-checks.py`: 4/4 (ruff format, ruff check, pytest 534 passed, pyright clean).
- Live verification with Playwright on the dev server: `/docs/nested-example` rendered on all three bundled themes (default, blue-tech, terminal); flat `/about` still 200; `/docs/no-such-page` and encoded traversal both 404.

*— Claude*