### PR TITLE
fix(deploy): point fly.toml at the data volume and keep one machine warm

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,15 +9,20 @@ primary_region = "sea"
   build-target = "prod"
 
 [env]
-  DATABASE_URL = "sqlite+aiosqlite:///data/squishmark.db"
+  # Four slashes: an absolute path targeting the mounted /data volume.
+  # Three would be relative to the workdir and skip the mount.
+  DATABASE_URL = "sqlite+aiosqlite:////data/squishmark.db"
   CACHE_TTL_SECONDS = "300"
+  GITHUB_CONTENT_REPO = "xeek-dev/squishmark-content"
 
 [http_service]
   internal_port = 8000
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  # Keep one machine warm: the content cache is in-memory, so a stopped
+  # machine wakes cold and loses webhook-warmed content.
+  min_machines_running = 1
   processes = ["app"]
 
 [[vm]]


### PR DESCRIPTION
## Summary

Production config fixes for the squishmark.xeek.dev deployment (#85, "Build squishmark.xeek.dev as a self-hosted SquishMark site").

## Changes

- **SQLite path bug**: `DATABASE_URL` used `sqlite+aiosqlite:///data/squishmark.db` (three slashes), which SQLAlchemy resolves relative to the container workdir (`/app/data/...`), silently bypassing the mounted `/data` volume. The database would not survive a redeploy. Now four slashes (absolute `/data/...`), matching the default in `config.py`.
- **Keep one machine warm**: `min_machines_running = 1`. The content cache is in-memory, so an auto-stopped machine wakes cold and loses webhook-warmed content.
- **Content repo**: set `GITHUB_CONTENT_REPO = "xeek-dev/squishmark-content"` for the official site.

## Testing

Config-only change; validated with `fly config validate` locally is not possible pre-auth, so this will be exercised by the first `fly deploy` for #85.

*— Claude*