### PR TITLE
chore(deploy): move Fly primary region to sjc

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@
 # See https://fly.io/docs/reference/configuration/ for documentation
 
 app = "squishmark"
-primary_region = "sea"
+primary_region = "sjc"
 
 [build]
   dockerfile = "Dockerfile"


### PR DESCRIPTION
Fly no longer offers the sea region (discovered at first deploy for #85, "Build squishmark.xeek.dev as a self-hosted SquishMark site"); sjc is the closest replacement. The squishmark_data volume was created in sjc.

*— Claude*