### PR TITLE
chore(deploy): move Fly primary region to dfw

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -2,7 +2,7 @@
 # See https://fly.io/docs/reference/configuration/ for documentation
 
 app = "squishmark"
-primary_region = "sea"
+primary_region = "dfw"
 
 [build]
   dockerfile = "Dockerfile"


### PR DESCRIPTION
Fly no longer offers the sea region the config targeted (discovered at first deploy for #85, "Build squishmark.xeek.dev as a self-hosted SquishMark site"). After discussing options, dfw (Dallas) was chosen for balanced North America latency. Replaces #136 (which targeted sjc).

The squishmark_data volume exists in dfw and the app machine has been moved there.

*— Claude*