### PR TITLE
fix(engine): keep the API explorer off /docs outside debug mode

### DIFF
--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -80,6 +80,12 @@ def create_app() -> FastAPI:
         version="0.1.0",
         debug=settings.debug,
         lifespan=lifespan,
+        # Outside debug, the API explorer must not occupy /docs, /redoc, and
+        # /openapi.json: those URLs belong to the site's own content (a blog's
+        # /docs page would otherwise be unreachable).
+        docs_url="/docs" if settings.debug else None,
+        redoc_url="/redoc" if settings.debug else None,
+        openapi_url="/openapi.json" if settings.debug else None,
     )
 
     # Custom exception handler for HTTP exceptions

--- a/tests/test_api_explorer_routes.py
+++ b/tests/test_api_explorer_routes.py
@@ -1,0 +1,30 @@
+"""The FastAPI API explorer must not shadow content URLs in production.
+
+With DEBUG off, /docs, /redoc, and /openapi.json fall through to the pages
+catch-all so a content repo can serve its own pages there (issue #140).
+With DEBUG on, the explorer stays available for engine development.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def test_docs_serves_content_page_in_production(fake_github, client: TestClient) -> None:
+    fake_github.files["pages/docs.md"] = "---\ntitle: Docs\n---\n\n# Docs\n\nGuides live here.\n"
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert "Guides live here" in resp.text
+
+
+def test_docs_not_swagger_in_production(client: TestClient) -> None:
+    resp = client.get("/docs")
+    # No pages/docs.md in the default fixture content: the catch-all 404s,
+    # but it must not be the Swagger UI page.
+    assert "swagger" not in resp.text.lower()
+
+
+def test_openapi_hidden_in_production(client: TestClient) -> None:
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Found while building the squishmark.dev docs section (#85): FastAPI mounts its interactive API explorer at /docs by default, and framework routes beat the pages catch-all, so a content page could never own /docs. Visitors got Swagger UI on a blog.

Closes #140 (FastAPI's built-in /docs route shadows content pages at /docs).

## Changes

- docs_url, redoc_url, and openapi_url are only set in debug mode; in production they're None, so /docs, /redoc, and /openapi.json fall through to the pages catch-all.
- Tests: /docs serves a content page in production, Swagger absent, /openapi.json 404s.

## Testing

run-checks 4/4 (format, lint, pytest 537 passed, pyright). Verified live on the dev server that /docs renders the site's docs page with DEBUG off.

*— Claude*