### PR TITLE
fix(engine): mount the API explorer only in debug mode

### DIFF
--- a/src/squishmark/main.py
+++ b/src/squishmark/main.py
@@ -80,6 +80,12 @@ def create_app() -> FastAPI:
         version="0.1.0",
         debug=settings.debug,
         lifespan=lifespan,
+        # Outside debug, the API explorer must not occupy /docs, /redoc, and
+        # /openapi.json: those URLs belong to the site's own content (a blog's
+        # /docs page would otherwise be unreachable).
+        docs_url="/docs" if settings.debug else None,
+        redoc_url="/redoc" if settings.debug else None,
+        openapi_url="/openapi.json" if settings.debug else None,
     )
 
     # Custom exception handler for HTTP exceptions

--- a/tests/test_api_explorer_routes.py
+++ b/tests/test_api_explorer_routes.py
@@ -1,0 +1,31 @@
+"""The FastAPI API explorer must not shadow content URLs in production.
+
+FastAPI mounts its explorer at /docs, /redoc, and /openapi.json by default.
+With DEBUG off those URLs must fall through to the generic pages catch-all
+so a content repo can serve its own page at any of them (issue #140).
+With DEBUG on, the explorer stays available for engine development.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.integration
+
+
+def test_content_page_can_own_a_framework_url_in_production(fake_github, client: TestClient) -> None:
+    fake_github.files["pages/docs.md"] = "---\ntitle: Docs\n---\n\n# Docs\n\nGuides live here.\n"
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert "Guides live here" in resp.text
+
+
+def test_api_explorer_absent_in_production(client: TestClient) -> None:
+    resp = client.get("/docs")
+    # No pages/docs.md in the default fixture content: the catch-all 404s,
+    # but it must not be the Swagger UI page.
+    assert "swagger" not in resp.text.lower()
+
+
+def test_openapi_schema_hidden_in_production(client: TestClient) -> None:
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

FastAPI mounts its interactive API explorer at /docs (plus /redoc and /openapi.json) by default, and framework routes beat the pages catch-all, so a content repo could never serve its own page at those URLs. Found while building the squishmark.dev site (#85). Replaces #141 with engine-appropriate naming: the fix is about the API explorer and framework URL ownership; documentation sections are purely a content-repo convention the engine knows nothing about.

Closes #140.

## Changes

- docs_url, redoc_url, and openapi_url are only set in debug mode; in production those URLs fall through to the generic pages catch-all like any other path.
- Tests: a content page can own a framework-default URL in production, the explorer is absent, and the OpenAPI schema 404s.

## Testing

run-checks 4/4 (format, lint, pytest, pyright). Verified live with DEBUG off: /docs renders content, /openapi.json 404s.

*— Claude*