### PR TITLE
chore(deploy): keep the engine fly.toml generic

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,16 +13,16 @@ primary_region = "dfw"
   # Three would be relative to the workdir and skip the mount.
   DATABASE_URL = "sqlite+aiosqlite:////data/squishmark.db"
   CACHE_TTL_SECONDS = "300"
-  GITHUB_CONTENT_REPO = "xeek-dev/squishmark-content"
+  # Set GITHUB_CONTENT_REPO via `fly secrets set` (see the deploy guide).
 
 [http_service]
   internal_port = 8000
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  # Keep one machine warm: the content cache is in-memory, so a stopped
-  # machine wakes cold and loses webhook-warmed content.
-  min_machines_running = 1
+  # 0 keeps costs down; bump to 1 to keep the in-memory content cache warm
+  # between visits.
+  min_machines_running = 0
   processes = ["app"]
 
 [[vm]]


### PR DESCRIPTION
## Summary

The engine's fly.toml doubles as the template users deploy from (the getting-started guide has them clone the repo and fly launch), but it had squishmark.dev-specific values baked in: our content repo in [env] and min_machines_running=1. A new user would have inherited our site's content repo by default.

Part of #85 (Build squishmark.xeek.dev as a self-hosted SquishMark site).

## Changes

- Drop GITHUB_CONTENT_REPO from [env]; the guide sets it via fly secrets, which is also where ours lives now.
- min_machines_running back to 0 (cheapest default for users), with a comment about bumping it to keep the content cache warm.
- The site's actual deploy config now lives in the content repo (deploy/fly.toml) and deploys with fly deploy -c.

## Testing

Config-only. The site deploy path was exercised with the relocated config (fly deploy -c from the content repo checkout).

*— Claude*