### PR TITLE
feat(engine): opt-in table of contents for pages

### DIFF
--- a/src/squishmark/models/content.py
+++ b/src/squishmark/models/content.py
@@ -142,6 +142,7 @@ class Page(BaseModel):
     image: str | None = None  # Featured image URL (used for og:image)
     visibility: Literal["public", "unlisted", "hidden"] = "public"
     nav_order: int | None = None  # Explicit ordering for navbar
+    toc: str = ""  # Rendered TOC fragment (HTML); pages opt in via frontmatter
 
     @property
     def url(self) -> str:

--- a/src/squishmark/services/markdown.py
+++ b/src/squishmark/services/markdown.py
@@ -222,10 +222,11 @@ class MarkdownService:
             Parsed Page object
         """
         frontmatter, markdown_content = self.parse_frontmatter(content)
-        # Pages don't carry a TOC by design — discard render_markdown's toc
-        # output so Page never gains a TOC field by accident.
-        html, _toc = self.render_markdown(markdown_content)
+        # Pages are opt-IN for the TOC (the reverse of posts): only an explicit
+        # `toc: true` in the frontmatter enables it, so short pages stay clean.
+        html, toc = self.render_markdown(markdown_content)
         html = rewrite_image_urls(html, path)
+        toc_enabled = "toc" in frontmatter.model_fields_set and frontmatter.toc
 
         # Extract slug from path, keeping subdirectories
         # (e.g., "pages/about.md" -> "about", "pages/docs/setup.md" -> "docs/setup")
@@ -250,6 +251,7 @@ class MarkdownService:
             image=frontmatter.image,
             visibility=frontmatter.visibility,
             nav_order=frontmatter.nav_order,
+            toc=toc if toc_enabled else "",
         )
 
     @staticmethod

--- a/tests/test_page_toc.py
+++ b/tests/test_page_toc.py
@@ -1,0 +1,37 @@
+"""Pages opt IN to the table of contents (issue #147).
+
+Posts default to showing a TOC (opt-out); pages default to none and enable
+it only with an explicit ``toc: true`` in frontmatter.
+"""
+
+import pytest
+
+from squishmark.services.markdown import MarkdownService
+
+BODY = "\n\n## First section\n\nText.\n\n## Second section\n\nMore text.\n"
+
+
+@pytest.fixture
+def markdown_service():
+    return MarkdownService()
+
+
+def test_page_toc_defaults_off(markdown_service):
+    page = markdown_service.parse_page("pages/guide.md", "---\ntitle: Guide\n---" + BODY)
+    assert page.toc == ""
+
+
+def test_page_toc_opt_in(markdown_service):
+    page = markdown_service.parse_page("pages/guide.md", "---\ntitle: Guide\ntoc: true\n---" + BODY)
+    assert page.toc
+    assert "first-section" in page.toc
+
+
+def test_page_toc_explicit_false(markdown_service):
+    page = markdown_service.parse_page("pages/guide.md", "---\ntitle: Guide\ntoc: false\n---" + BODY)
+    assert page.toc == ""
+
+
+def test_page_toc_opt_in_headingless_is_empty(markdown_service):
+    page = markdown_service.parse_page("pages/guide.md", "---\ntitle: Guide\ntoc: true\n---\n\nJust a paragraph.\n")
+    assert page.toc == ""

--- a/themes/blue-tech/page.html
+++ b/themes/blue-tech/page.html
@@ -25,6 +25,13 @@
     </aside>
     {% endif %}
 
+    {% if page.toc %}
+    <details class="post-toc">
+        <summary>Contents</summary>
+        {{ page.toc | safe }}
+    </details>
+    {% endif %}
+
     <div class="page-content">
         {{ page.html | safe }}
     </div>

--- a/themes/default/page.html
+++ b/themes/default/page.html
@@ -25,6 +25,13 @@
     </aside>
     {% endif %}
 
+    {% if page.toc %}
+    <aside class="post-toc" aria-label="Table of contents">
+        <p class="post-toc-title">Contents</p>
+        {{ page.toc | safe }}
+    </aside>
+    {% endif %}
+
     <div class="page-content">
         {{ page.html | safe }}
     </div>

--- a/themes/terminal/page.html
+++ b/themes/terminal/page.html
@@ -25,6 +25,13 @@
     </aside>
     {% endif %}
 
+    {% if page.toc %}
+    <aside class="post-toc" aria-label="Table of contents">
+        <div class="post-toc-label">// contents</div>
+        {{ page.toc | safe }}
+    </aside>
+    {% endif %}
+
     <div class="page-content">
         {{ page.html | safe }}
     </div>


### PR DESCRIPTION
## Summary

Long-form pages (guides, reference material) had no way to show a table of contents; parse_page threw the rendered TOC away. Surfaced while building the squishmark.dev getting-started guide (#85).

Closes #147 (Pages can't show a table of contents).

## Changes

- Page model gains a toc field; parse_page threads the rendered fragment through only when frontmatter explicitly sets toc: true (detected via model_fields_set, so posts' opt-out default is untouched)
- page.html in all three bundled themes renders the page TOC with the same markup as that theme's post TOC
- Tests: default off, opt-in, explicit false, headingless opt-in

## Testing

run-checks 4/4. Verified live on the dev server with a toc: true page in all three themes (default, blue-tech, terminal).

*— Claude*