### PR TITLE
fix(engine): warm content at the pushed commit SHA

### DIFF
--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import hmac
+import json
+import string
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -64,6 +66,22 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
     if event != "push":
         return {"status": "ignored", "event": event}
 
+    # Pin content fetches to the pushed commit. Fetching by SHA sidesteps
+    # the raw CDN's branch-path caching, which can otherwise serve the
+    # pre-push file for minutes and poison the warm below (issue #138).
+    github_service = services.github
+    pinned_ref = None
+    try:
+        payload = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        payload = {}
+    after = payload.get("after", "")
+    branch = payload.get("ref", "")
+    is_sha = len(after) == 40 and set(after) <= set(string.hexdigits.lower()) and set(after) != {"0"}
+    if branch == f"refs/heads/{github_service.DEFAULT_BRANCH}" and is_sha:
+        github_service.pin_content_ref(after)
+        pinned_ref = after
+
     # Refresh cache
     cache = services.cache
     cleared = await cache.clear()
@@ -97,4 +115,5 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
         "status": "ok",
         "cleared": cleared,
         "warmed": cache.size,
+        "content_ref": pinned_ref or github_service.DEFAULT_BRANCH,
     }

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -73,7 +73,7 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
     pinned_ref = None
     try:
         payload = json.loads(body)
-    except (ValueError, UnicodeDecodeError):
+    except ValueError, UnicodeDecodeError:
         payload = {}
     after = payload.get("after", "")
     branch = payload.get("ref", "")

--- a/src/squishmark/routers/webhooks.py
+++ b/src/squishmark/routers/webhooks.py
@@ -75,7 +75,7 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
         payload = json.loads(body)
     except ValueError, UnicodeDecodeError:
         payload = {}
-    after = payload.get("after", "")
+    after = str(payload.get("after") or "").lower()
     branch = payload.get("ref", "")
     is_sha = len(after) == 40 and set(after) <= set(string.hexdigits.lower()) and set(after) != {"0"}
     if branch == f"refs/heads/{github_service.DEFAULT_BRANCH}" and is_sha:
@@ -115,5 +115,5 @@ async def github_webhook(request: Request, services: ServicesDep, theme_engine: 
         "status": "ok",
         "cleared": cleared,
         "warmed": cache.size,
-        "content_ref": pinned_ref or github_service.DEFAULT_BRANCH,
+        "content_ref": pinned_ref or github_service.content_ref,
     }

--- a/src/squishmark/services/github.py
+++ b/src/squishmark/services/github.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -37,11 +38,33 @@ class GitHubService:
 
     GITHUB_API_BASE = "https://api.github.com"
     GITHUB_RAW_BASE = "https://raw.githubusercontent.com"
+    DEFAULT_BRANCH = "main"
 
     def __init__(self, settings: Settings, cache: Cache) -> None:
         self.settings = settings
         self.cache = cache
         self._client: httpx.AsyncClient | None = None
+        self._pinned_ref: str | None = None
+        self._pin_expires: float = 0.0
+
+    def pin_content_ref(self, ref: str, ttl_seconds: float = 600) -> None:
+        """Pin content fetches to a specific commit for a bounded time.
+
+        The push webhook pins fetches to the pushed commit's SHA: commit
+        URLs are immutable, so the raw CDN can never serve a stale copy of
+        them, unlike branch-path URLs which it caches for minutes. The pin
+        expires so a missed webhook can never strand the site on an old
+        commit; after expiry, fetches return to the branch head.
+        """
+        self._pinned_ref = ref
+        self._pin_expires = time.monotonic() + ttl_seconds
+
+    @property
+    def content_ref(self) -> str:
+        """The ref content is fetched at: a pinned commit, or the branch."""
+        if self._pinned_ref and time.monotonic() < self._pin_expires:
+            return self._pinned_ref
+        return self.DEFAULT_BRANCH
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create the HTTP client."""
@@ -101,18 +124,20 @@ class GitHubService:
             logger.warning("Failed to fetch %s from GitHub: %s", url, exc)
             return None
 
-    async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
+    async def get_file(self, path: str, ref: str | None = None, use_cache: bool = True) -> GitHubFile | None:
         """
         Fetch a file from the content repository.
 
         Args:
             path: Path to the file within the repository
-            ref: Git ref (branch, tag, or commit) - only used for GitHub
+            ref: Git ref (branch, tag, or commit) - only used for GitHub.
+                Defaults to the current content ref (see ``content_ref``).
             use_cache: Whether to use cached content
 
         Returns:
             GitHubFile if found, None otherwise
         """
+        ref = ref or self.content_ref
         cache_key = f"file:{path}:{ref}"
 
         # Check cache first
@@ -191,7 +216,9 @@ class GitHubService:
             logger.warning("Failed to fetch binary %s from GitHub: %s", url, exc)
             return None
 
-    async def get_binary_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubBinaryFile | None:
+    async def get_binary_file(
+        self, path: str, ref: str | None = None, use_cache: bool = True
+    ) -> GitHubBinaryFile | None:
         """
         Fetch a binary file from the content repository.
 
@@ -203,6 +230,7 @@ class GitHubService:
         Returns:
             GitHubBinaryFile if found, None otherwise
         """
+        ref = ref or self.content_ref
         cache_key = f"binary:{path}:{ref}"
 
         if use_cache:
@@ -300,7 +328,7 @@ class GitHubService:
             return []
 
     async def list_directory(
-        self, path: str, ref: str = "main", use_cache: bool = True, recursive: bool = False
+        self, path: str, ref: str | None = None, use_cache: bool = True, recursive: bool = False
     ) -> list[str]:
         """
         List files in a directory.
@@ -314,6 +342,7 @@ class GitHubService:
         Returns:
             List of file paths within the directory
         """
+        ref = ref or self.content_ref
         cache_key = f"dir:{path}:{ref}:{int(recursive)}"
 
         # Check cache first

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,8 @@ class FakeGitHubService:
     GitHub/local directory.
     """
 
+    DEFAULT_BRANCH = "main"
+
     def __init__(
         self,
         files: dict[str, str] | None = None,
@@ -46,6 +48,10 @@ class FakeGitHubService:
         self.files: dict[str, str] = dict(files or {})
         self.binary_files: dict[str, bytes] = dict(binary_files or {})
         self.config: dict[str, Any] | None = config
+        self.pinned_refs: list[str] = []
+
+    def pin_content_ref(self, ref: str, ttl_seconds: float = 600) -> None:
+        self.pinned_refs.append(ref)
 
     async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
         content = self.files.get(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,10 @@ class FakeGitHubService:
     def pin_content_ref(self, ref: str, ttl_seconds: float = 600) -> None:
         self.pinned_refs.append(ref)
 
+    @property
+    def content_ref(self) -> str:
+        return self.pinned_refs[-1] if self.pinned_refs else self.DEFAULT_BRANCH
+
     async def get_file(self, path: str, ref: str = "main", use_cache: bool = True) -> GitHubFile | None:
         content = self.files.get(path)
         if content is None:

--- a/tests/test_content_ref_pinning.py
+++ b/tests/test_content_ref_pinning.py
@@ -1,0 +1,112 @@
+"""Webhook pins content fetches to the pushed commit (issue #138).
+
+Branch-path fetches from raw.githubusercontent.com go through a CDN that can
+serve the pre-push file for minutes, so the webhook's cache warm could pin
+stale content. Commit-SHA URLs are immutable, so the push handler pins the
+service to the payload's ``after`` SHA for a bounded time.
+"""
+
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from squishmark.config import Settings
+from squishmark.services.cache import Cache
+from squishmark.services.github import GitHubService
+
+SHA = "a" * 39 + "b"
+
+
+# --- Unit: pin semantics -----------------------------------------------------
+
+
+def _service() -> GitHubService:
+    return GitHubService(Settings(github_content_repo="owner/repo"), Cache(ttl_seconds=300))
+
+
+def test_content_ref_defaults_to_branch():
+    assert _service().content_ref == "main"
+
+
+def test_pin_takes_effect_and_expires(monkeypatch):
+    service = _service()
+    now = 1000.0
+    monkeypatch.setattr("squishmark.services.github.time.monotonic", lambda: now)
+    service.pin_content_ref(SHA, ttl_seconds=600)
+    assert service.content_ref == SHA
+
+    now = 1599.0
+    assert service.content_ref == SHA
+    now = 1601.0
+    assert service.content_ref == "main"
+
+
+@pytest.mark.asyncio
+async def test_fetches_use_pinned_sha_in_urls():
+    service = _service()
+    service.pin_content_ref(SHA)
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, text="content")
+
+    service._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    await service.get_file("posts/a.md", use_cache=False)
+    assert seen and f"/owner/repo/{SHA}/posts/a.md" in seen[0]
+    await service.close()
+
+
+# --- Integration: webhook pins from the payload ------------------------------
+
+pytestmark_integration = pytest.mark.integration
+
+WEBHOOK_SECRET = "test-webhook-secret"  # matches the autouse fixture
+
+
+def _signed_headers(body: bytes) -> dict[str, str]:
+    digest = hmac.new(WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return {
+        "X-Hub-Signature-256": f"sha256={digest}",
+        "X-GitHub-Event": "push",
+        "Content-Type": "application/json",
+    }
+
+
+@pytest.mark.integration
+def test_push_pins_to_after_sha(fake_github, client: TestClient) -> None:
+    body = json.dumps({"ref": "refs/heads/main", "after": SHA}).encode()
+    resp = client.post("/webhooks/github", content=body, headers=_signed_headers(body))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["content_ref"] == SHA
+    assert fake_github.pinned_refs == [SHA]
+
+
+@pytest.mark.integration
+def test_push_to_other_branch_does_not_pin(fake_github, client: TestClient) -> None:
+    body = json.dumps({"ref": "refs/heads/feature", "after": SHA}).encode()
+    resp = client.post("/webhooks/github", content=body, headers=_signed_headers(body))
+    assert resp.status_code == 200
+    assert resp.json()["content_ref"] == "main"
+    assert fake_github.pinned_refs == []
+
+
+@pytest.mark.integration
+def test_branch_deletion_zero_sha_does_not_pin(fake_github, client: TestClient) -> None:
+    body = json.dumps({"ref": "refs/heads/main", "after": "0" * 40}).encode()
+    resp = client.post("/webhooks/github", content=body, headers=_signed_headers(body))
+    assert resp.status_code == 200
+    assert fake_github.pinned_refs == []
+
+
+@pytest.mark.integration
+def test_unparseable_payload_still_refreshes(fake_github, client: TestClient) -> None:
+    body = b"not json"
+    resp = client.post("/webhooks/github", content=body, headers=_signed_headers(body))
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert fake_github.pinned_refs == []

--- a/tests/test_content_ref_pinning.py
+++ b/tests/test_content_ref_pinning.py
@@ -63,8 +63,6 @@ async def test_fetches_use_pinned_sha_in_urls():
 
 # --- Integration: webhook pins from the payload ------------------------------
 
-pytestmark_integration = pytest.mark.integration
-
 WEBHOOK_SECRET = "test-webhook-secret"  # matches the autouse fixture
 
 


### PR DESCRIPTION
## Summary

Fixes the raw-CDN race that hit squishmark.dev three times on launch day: push, webhook fires, engine re-warms its cache, but GitHub's raw CDN still serves the pre-push file for a few minutes, so the warm re-caches stale content for a full TTL.

Closes #138 (Webhook cache warm can pin stale content from the raw CDN).

## Changes

- GitHubService gains a bounded content-ref pin: `pin_content_ref(sha, ttl)` plus a `content_ref` property. get_file, get_binary_file, and list_directory resolve their ref through it when the caller doesn't pass one (cache keys already carry the ref).
- The push webhook pins to the payload's `after` SHA before clearing and warming, when the push targets the default branch and the SHA is a real commit (branch deletions' zero-SHA and other-branch pushes are ignored; unparseable payloads still refresh as before).
- The pin expires after 10 minutes: commit-URL fetches are immune to CDN staleness while it holds, and a missed webhook can never strand the site on an old commit because fetches fall back to the branch head.
- The webhook response now reports `content_ref` for observability.

## Testing

- Unit: pin default/expiry semantics, and a MockTransport assertion that fetch URLs actually carry the pinned SHA.
- Integration: signed push pins and reports the SHA; other-branch pushes, zero-SHA deletions, and unparseable payloads don't pin but still refresh.
- run-checks 4/4 (format, lint, pytest, pyright).
- Real-world verification after deploy: push a content change and confirm the live page reflects it immediately (the exact scenario that failed three times today).

*— Claude*