### PR TITLE
ci(release): publish the container image to GHCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -14,6 +14,10 @@ permissions:
 
 jobs:
   publish:
+    # Releases publish from their tag; manual runs only from main, so a
+    # dispatch from a feature branch can never overwrite latest with
+    # unreleased code.
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,53 @@
+name: Publish image
+
+# Publishes the production container image to GHCR on every release
+# (release-please publishes releases when its PR merges). The manual
+# trigger exists for verification and one-off republishes.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Release tags (vX.Y.Z) get version tags plus latest; a manual run
+      # from a branch publishes latest only.
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      # linux/amd64 covers servers (Fly included); linux/arm64 covers the
+      # local Docker preview on Apple Silicon.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: prod
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

The README (pre-rework) told users to docker pull ghcr.io/xeek-dev/squishmark:latest, but no publish workflow ever existed, so the package doesn't. This adds it.

Closes #146 (Publish the container image to GHCR on release).

## Changes

- .github/workflows/publish-image.yml: on release publication (which release-please produces), build the Dockerfile's prod stage for linux/amd64 (servers, Fly) and linux/arm64 (Apple Silicon local previews) and push to GHCR tagged with the semver version, major.minor, and latest. GITHUB_TOKEN with packages: write; no new secrets.
- workflow_dispatch trigger for verification and one-off republishes.

## Verification plan (post-merge, in order)

1. Trigger the manual run on main and watch it push
2. One-time UI step (owner): package settings -> change visibility -> public (GHCR packages are born private and there's no API for this)
3. docker pull ghcr.io/xeek-dev/squishmark:latest from a clean state and run it against a content repo
4. Follow-up PR restores the README's docker pull instructions

*— Claude*