### PR TITLE
docs(readme): restore docker pull instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ print("Hello from SquishMark!")
 ```
 ````
 
-Prefer Docker? Any Docker host works; build the image from this repo (a published image is planned, [#146](https://github.com/xeek-dev/squishmark/issues/146)):
+Prefer Docker? Any Docker host works; the image is published for amd64 and arm64:
 
 ```bash
-docker build -t squishmark .
 docker run -d -p 8000:8000 \
   -v squishmark_data:/data \
   -e GITHUB_CONTENT_REPO=your-username/your-content-repo \
-  squishmark
+  ghcr.io/xeek-dev/squishmark:latest
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

Follow-up to #152: the GHCR image now exists and is public, so the README's Docker path returns to a plain docker run of the published image instead of the build-from-source workaround.

## Testing

Verified from a clean state: docker logout ghcr.io, anonymous docker pull, and a run against the squishmark-starter repo served a live blog (health 200, homepage rendered).

*— Claude*