### PR TITLE
ci(release): auto-deploy the site on minor and major releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,3 +44,19 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Minor and major releases (x.y.0) roll to squishmark.dev automatically;
+  # patch releases wait for the content repo's manual deploy button.
+  deploy-site:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true' && endsWith(needs.release-please.outputs.version, '.0')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch site deploy
+        env:
+          GH_TOKEN: ${{ secrets.CONTENT_DISPATCH_TOKEN }}
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          gh api -X POST repos/xeek-dev/squishmark-content/dispatches \
+            -f event_type=engine-release \
+            -f "client_payload[version]=${VERSION}"


### PR DESCRIPTION
## Summary

Completes the deploy formalization: engine releases with a zero patch digit (1.1.0, 2.0.0) dispatch the content repo's Deploy site workflow, which ships the exact released GHCR image to Fly. Patch releases (1.0.1...) deliberately do not auto-deploy; the content repo's manual workflow button covers those and rollbacks.

## Wiring

- Content repo side already live: deploy-site.yml (repository_dispatch engine-release + workflow_dispatch with a version input), FLY_API_TOKEN secret set from a scoped Fly deploy token.
- This PR adds the sender: a deploy-site job gated on release_created and endsWith(version, '.0').
- Requires a CONTENT_DISPATCH_TOKEN secret in this repo: fine-grained PAT scoped to squishmark-content with Contents read/write (repository_dispatch needs it). Until it's set, the job fails harmlessly on x.y.0 releases and the manual button still works.

## Testing

The content-repo workflow was proven with a manual run deploying 1.0.0. The dispatch path gets its first live test on the next x.y.0 release.

*— Claude*